### PR TITLE
Migrate GitHub integration to GitHub App (installation token flow)

### DIFF
--- a/backend/src/controllers/integration/github.auth.controller.js
+++ b/backend/src/controllers/integration/github.auth.controller.js
@@ -1,0 +1,44 @@
+import { AppError } from "../../utils/AppErrors.js";
+import { getGithubAppInstallUrl } from "../../services/integration/github/githubApp.service.js";
+import { handleGithubAppSetupCallback } from "../../services/integration/github/github.auth.service.js";
+
+export const startGithubAppInstall = async (req, res) => {
+  try {
+    const { workflowId } = req.query;
+    const userId = req.user.userId;
+
+    if (!workflowId) {
+      throw new AppError("Invalid request! WorkflowId is missing!", 400);
+    }
+
+    const url = getGithubAppInstallUrl(userId, workflowId);
+    return res.redirect(url);
+  } catch (error) {
+    return res.status(error.statusCode || 500).json({
+      success: false,
+      message: error.message || "Internal Server Error!",
+    });
+  }
+};
+
+export const handleGithubAppSetup = async (req, res) => {
+  try {
+    const { installation_id: installationId, state, setup_action: setupAction } = req.query;
+
+    if (!installationId || setupAction !== "install") {
+      return res.redirect("http://localhost:5173/workflow/");
+    }
+
+    const decodedState = JSON.parse(Buffer.from(state, "base64").toString("utf-8"));
+    const { workflowId, userId } = decodedState;
+
+    await handleGithubAppSetupCallback({ installationId, userId });
+
+    return res.redirect(`http://localhost:5173/workflow/${workflowId}`);
+  } catch (error) {
+    return res.status(error.statusCode || 500).json({
+      success: false,
+      message: error.message || "Internal Server Error!",
+    });
+  }
+};

--- a/backend/src/controllers/integration/github.webhook.controller.js
+++ b/backend/src/controllers/integration/github.webhook.controller.js
@@ -1,0 +1,28 @@
+import { processGithubInstallationWebhook } from "../../services/integration/github/githubWebhook.service.js";
+
+export const handleGithubWebhook = async (req, res) => {
+  try {
+    const event = req.headers["x-github-event"];
+
+    if (event !== "installation") {
+      return res.status(200).json({
+        received: true,
+        ignored: true,
+        reason: "Non-installation event",
+      });
+    }
+
+    const result = await processGithubInstallationWebhook(req.body || {});
+
+    return res.status(200).json({
+      received: true,
+      success: true,
+      data: result,
+    });
+  } catch (error) {
+    return res.status(error.statusCode || 500).json({
+      success: false,
+      message: error.message || "Failed to process GitHub webhook",
+    });
+  }
+};

--- a/backend/src/controllers/webhook.controllers.js
+++ b/backend/src/controllers/webhook.controllers.js
@@ -1,96 +1,53 @@
-import { 
-    manualExecuteWorkflowService,
-    googleFormExecuteWorkflowService
- } from "../services/workflow/inngest/workflowEcecute.js";
+import {
+  manualExecuteWorkflowService,
+  googleFormExecuteWorkflowService,
+} from "../services/workflow/inngest/workflowEcecute.js";
 
 export const manualExecuteWorkflow = async (req, res) => {
-    try {
-        const { workflowId } = req.params;
-        
-        if (!workflowId) {
-            return res.status(400).json({
-                message: "WorkflowId not found! Bad request.",
-                success: false
-            });
-        }
-        await manualExecuteWorkflowService(req.user, workflowId);
-        
-        return res.status(200).json({
-            message: "Workflow Executed Successfully.",
-            success: true,
-        })
-    } catch (error) {
-        console.log(error);
-        return res.status(500).json({
-                message: error.message || "Bad Request",
-                success: false
-            })
+  try {
+    const { workflowId } = req.params;
+
+    if (!workflowId) {
+      return res.status(400).json({
+        message: "WorkflowId not found! Bad request.",
+        success: false,
+      });
     }
-}
+    await manualExecuteWorkflowService(req.user, workflowId);
+
+    return res.status(200).json({
+      message: "Workflow Executed Successfully.",
+      success: true,
+    });
+  } catch (error) {
+    console.log(error);
+    return res.status(500).json({
+      message: error.message || "Bad Request",
+      success: false,
+    });
+  }
+};
 
 export const googleFormExecuteWorkflow = async (req, res) => {
-    try {
-        const {workflowId} = req.params;
+  try {
+    const { workflowId } = req.params;
 
-        if (!workflowId) {
-            return res.status(400).json({
-                message: "WorkflowId not found! Bad request.",
-                success: false
-            });
-        }
-
-        await googleFormExecuteWorkflowService(workflowId, req.body);
-        return res.status(200).json({
-            recived: true,
-            success: true,
-        })
-    } catch (error) {
-        console.log(error);
-        res.status(500).json({
-            success: false,
-        })
+    if (!workflowId) {
+      return res.status(400).json({
+        message: "WorkflowId not found! Bad request.",
+        success: false,
+      });
     }
-}
 
-export const handleGithubWebhook = async (req, res) => {
-    try {
-        const event = req.headers["x-github-event"] || req.headers["X-GitHub-Event"];
-        const delivery = req.headers["x-github-delivery"] || req.headers["X-GitHub-Delivery"];
-        const payload = req.body || {};
-
-        console.log("--- GitHub Webhook Received ---");
-        console.log("Event:", event);
-        console.log("Delivery:", delivery);
-
-        console.log("Repository:", payload.repository?.full_name || payload.repository?.name);
-        if (payload.action) console.log("Action:", payload.action);
-
-        if (payload.issue) {
-            console.log("Issue:", {
-                number: payload.issue.number,
-                title: payload.issue.title,
-                url: payload.issue.html_url,
-            });
-        }
-
-        if (payload.head_commit) {
-            console.log("Head commit:", {
-                id: payload.head_commit.id,
-                message: payload.head_commit.message,
-                url: payload.head_commit.url,
-            });
-        }
-
-        if (payload.commits && Array.isArray(payload.commits)) {
-            console.log("Commits count:", payload.commits.length);
-        }
-
-        console.log("Sender:", payload.sender?.login || payload.sender?.name);
-        console.log("--- End GitHub Webhook ---");
-
-        return res.status(200).json({ received: true });
-    } catch (error) {
-        console.error("handleGithubWebhook error:", error);
-        return res.status(500).json({ success: false });
-    }
-}
+    await googleFormExecuteWorkflowService(workflowId, req.body);
+    return res.status(200).json({
+      recived: true,
+      success: true,
+    });
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({
+      success: false,
+    });
+  }
+};

--- a/backend/src/models/integration/integration.model.js
+++ b/backend/src/models/integration/integration.model.js
@@ -11,44 +11,45 @@ const query = async (sql, params = [], client = pool) => {
   }
 };
 
-export const Integration = {        // external_id == team.id for slack
+export const Integration = {
+  sameIntegrationExists: async ({ userId, provider, externalId }, client = pool) => {
+    const rows = await query(
+      "SELECT EXISTS (SELECT 1 FROM integrations WHERE user_id = ? AND provider = ? AND external_id = ?) AS sameIntegrationExists",
+      [userId, provider, externalId],
+      client,
+    );
+    return Number(rows[0].sameIntegrationExists) === 1;
+  },
 
-    sameIntegrationExists: async({userId, provider, externalId}, client = pool) => {
-        const rows = await query(
-            "SELECT EXISTS (SELECT 1 FROM integrations WHERE user_id = ? AND provider = ? AND external_id = ?) AS sameIntegrationExists",
-            [userId, provider, externalId], 
-            client
-        );
-        return Number(rows[0].sameIntegrationExists) === 1;
-    },
-
-    insertTokenProvider: async({userId, provider, externalId, name}, client = pool) => {
-        const rows = await query(
-            `INSERT INTO integrations (user_id, provider, external_id, name) VALUES (?, ?, ?, ?) 
-            ON DUPLICATE KEY UPDATE 
+  insertTokenProvider: async ({ userId, provider, externalId, name }, client = pool) => {
+    const rows = await query(
+      `INSERT INTO integrations (user_id, provider, external_id, name) VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
             name = VALUES(name),
             id = LAST_INSERT_ID(id) `,
-            [userId, provider, externalId, name], 
-            client
-        );
+      [userId, provider, externalId, name],
+      client,
+    );
 
-        return rows;
+    return rows;
+  },
+
+  insertOAuthToken: async (
+    {
+      integrationId,
+      accessToken,
+      refreshToken,
+      tokenType,
+      scope,
+      expiresAt,
+      last_refreshed_at,
     },
-
-    insertOAuthToken: async ({ 
-            integrationId, 
-            accessToken, 
-            refreshToken, 
-            tokenType, 
-            scope, 
-            expiresAt, 
-            last_refreshed_at 
-        }, client = pool) => {
-
-        const rows = await query(
-            `INSERT INTO integration_accounts (integration_id, access_token, refresh_token, token_type, scope, expires_at, last_refreshed_at)
+    client = pool,
+  ) => {
+    const rows = await query(
+      `INSERT INTO integration_accounts (integration_id, access_token, refresh_token, token_type, scope, expires_at, last_refreshed_at)
             VALUES (?, ?, ?, ?, ?, ?, ?)
-            ON DUPLICATE KEY UPDATE 
+            ON DUPLICATE KEY UPDATE
             access_token = VALUES(access_token),
             refresh_token = COALESCE(VALUES(refresh_token), refresh_token),
             token_type = VALUES(token_type),
@@ -56,16 +57,16 @@ export const Integration = {        // external_id == team.id for slack
             expires_at = VALUES(expires_at),
             last_refreshed_at = VALUES(last_refreshed_at)
             `,
-            [integrationId, accessToken, refreshToken, tokenType, scope, expiresAt, last_refreshed_at], 
-            client
-        );
+      [integrationId, accessToken, refreshToken, tokenType, scope, expiresAt, last_refreshed_at],
+      client,
+    );
 
-        return rows[0];
-    },
+    return rows[0];
+  },
 
-    getIntegration: async({userId, provider}, client = pool) => {
-        const rows = await query(
-            `SELECT
+  getIntegration: async ({ userId, provider }, client = pool) => {
+    const rows = await query(
+      `SELECT
                 i.id,
                 i.name,
                 i.provider,
@@ -79,39 +80,52 @@ export const Integration = {        // external_id == team.id for slack
             FROM integrations AS i
             INNER JOIN integration_accounts AS ia ON i.id = ia.integration_id
             WHERE i.user_id = ? AND i.provider = ?`,
-            [userId, provider],
-            client
-        );
-        
-        return rows;
-    },
+      [userId, provider],
+      client,
+    );
 
-    getIntegrationAccountToken: async ({ userId, provider, externalId }, client = pool) => {
-        const rows = await query(
-            `SELECT ia.access_token
+    return rows;
+  },
+
+  getIntegrationByProviderAndExternalId: async ({ provider, externalId }, client = pool) => {
+    const rows = await query(
+      `SELECT i.id, i.user_id, i.provider, i.external_id, i.name
+       FROM integrations AS i
+       WHERE i.provider = ? AND i.external_id = ?
+       LIMIT 1`,
+      [provider, externalId],
+      client,
+    );
+
+    return rows[0] || null;
+  },
+
+  getIntegrationAccountToken: async ({ userId, provider, externalId }, client = pool) => {
+    const rows = await query(
+      `SELECT ia.access_token
             FROM integrations AS i
             INNER JOIN integration_accounts AS ia ON i.id = ia.integration_id
             WHERE i.user_id = ? AND i.provider = ? AND i.external_id = ?
             LIMIT 1`,
-            [userId, provider, externalId],
-            client
-        );
+      [userId, provider, externalId],
+      client,
+    );
 
-        return rows[0]?.access_token || null;
-    },
+    return rows[0]?.access_token || null;
+  },
 
-    getScopes: async ({userId, provider}, client = pool) => {
-        const rows = await query(
-            `SELECT i.id, i.user_id, i.provider, ia.scope
+  getScopes: async ({ userId, provider }, client = pool) => {
+    const rows = await query(
+      `SELECT i.id, i.user_id, i.provider, ia.scope
             FROM integrations AS i
             INNER JOIN integration_accounts AS ia ON i.id = ia.integration_id
             WHERE i.user_id = ? AND i.provider = ?
             LIMIT 1
             `,
-            [userId, provider],
-            client
-        );
+      [userId, provider],
+      client,
+    );
 
-        return rows[0] || null;
-    }
-}
+    return rows[0] || null;
+  },
+};

--- a/backend/src/routes/integration/integration.auth.routes.js
+++ b/backend/src/routes/integration/integration.auth.routes.js
@@ -2,13 +2,18 @@ import express from "express";
 import { authMiddleware } from "../../middlewares/auth.middleware.js";
 import { startOAuth, handleOAuthCallback } from "../../controllers/integration/OAuth/auth.integration.controller.js";
 import { getIntegrationController } from "../../controllers/integration/crud/crud.integration.controller.js";
+import {
+  handleGithubAppSetup,
+  startGithubAppInstall,
+} from "../../controllers/integration/github.auth.controller.js";
 
 const router = express.Router();
 
-//router.use(authMiddleware);
+router.get("/oauth/github/connect", authMiddleware, startGithubAppInstall);
+router.get("/oauth/github/callback", handleGithubAppSetup);
 
 router.get("/oauth/:provider/connect", authMiddleware, startOAuth);
 router.get("/oauth/:provider/callback", handleOAuthCallback);
-router.get("/:provider/get/integration", authMiddleware ,getIntegrationController);
+router.get("/:provider/get/integration", authMiddleware, getIntegrationController);
 
 export default router;

--- a/backend/src/routes/webhook.route.js
+++ b/backend/src/routes/webhook.route.js
@@ -1,17 +1,15 @@
 import express from "express";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
-import { 
-    manualExecuteWorkflow, 
-    googleFormExecuteWorkflow,
-    handleGithubWebhook,
+import {
+  manualExecuteWorkflow,
+  googleFormExecuteWorkflow,
 } from "../controllers/webhook.controllers.js";
+import { handleGithubWebhook } from "../controllers/integration/github.webhook.controller.js";
 
 const router = express.Router();
 
-router.post("/:workflowId/execute", authMiddleware, manualExecuteWorkflow)
+router.post("/:workflowId/execute", authMiddleware, manualExecuteWorkflow);
 router.post("/google-form/:workflowId/", googleFormExecuteWorkflow);
 router.post("/github", handleGithubWebhook);
 
-export default router
-
-//TODO: Check the user auth(if we can) sort structure of mannual execution and webhook execution. We can have separate controller for webhook execution and manual execution.
+export default router;

--- a/backend/src/services/integration/github/github.auth.service.js
+++ b/backend/src/services/integration/github/github.auth.service.js
@@ -1,176 +1,26 @@
-import axios from "axios";
-import pool from "../../../config/db.js";
-import { Integration } from "../../../models/integration/integration.model.js";
 import { AppError } from "../../../utils/AppErrors.js";
+import {
+  exchangeInstallationToken,
+  fetchInstallationMetadata,
+} from "./githubApp.service.js";
+import { upsertGithubInstallation } from "./githubWebhook.service.js";
 
-export const getGithubAuthUrl = (userId, workflowId, provider) => {
-  const base = "https://github.com/login/oauth/authorize";
-
-  if (!process.env.GITHUB_CLIENT_ID || !process.env.GITHUB_REDIRECT_URI) {
-    throw new AppError("Missing GitHub OAuth environment configuration.", 500);
+export const handleGithubAppSetupCallback = async ({ installationId, userId }) => {
+  if (!installationId || !userId) {
+    throw new AppError("Missing installationId or userId in GitHub setup callback.", 400);
   }
 
-  const stateData = {
-    workflowId,
+  const { token, expiresAt } = await exchangeInstallationToken(String(installationId));
+  const metadata = await fetchInstallationMetadata(String(installationId), token);
+
+  await upsertGithubInstallation({
     userId,
-    provider,
-  };
-
-  const state = Buffer.from(JSON.stringify(stateData)).toString("base64");
-
-  const params = new URLSearchParams({
-    client_id: process.env.GITHUB_CLIENT_ID,
-    redirect_uri: process.env.GITHUB_REDIRECT_URI,
-    scope: process.env.GITHUB_SCOPES,
-    state,
+    installationId,
+    accountLogin: metadata.account.login,
+    repositorySelection: metadata.repositorySelection,
+    installationToken: token,
+    expiresAt,
   });
 
-  return `${base}?${params.toString()}`;
-};
-
-export const handleGithubCallback = async (code, userId) => {
-  try {
-    const formData = new URLSearchParams({
-      client_id: process.env.GITHUB_CLIENT_ID,
-      client_secret: process.env.GITHUB_CLIENT_SECRET_KEY,
-      code,
-      redirect_uri: process.env.GITHUB_REDIRECT_URI,
-    });
-
-    const tokenResponse = await axios.post(
-      "https://github.com/login/oauth/access_token",
-      formData.toString(),
-      {
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Accept: "application/json",
-        },
-      },
-    );
-
-    const tokenData = tokenResponse.data;
-
-    if (!tokenData?.access_token) {
-      throw new AppError("GitHub OAuth failed", 500);
-    }
-
-    const profileResponse = await axios.get("https://api.github.com/user", {
-      headers: {
-        Authorization: `Bearer ${tokenData.access_token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    });
-
-    const profile = profileResponse.data;
-    
-    return {
-      userId,
-      provider: "github",
-      externalId: String(profile.id),
-      name: profile.name || profile.login,
-      scope: tokenData.scope || null,               // GitHub returns scopes as empty string, we can also strore the scopes from the .env variable.
-      tokenType: tokenData.token_type || "bearer",
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token || null,
-      expiresAt: tokenData.expires_in
-        ? new Date(Date.now() + tokenData.expires_in * 1000)
-        : null,
-      last_refreshed_at: new Date(),
-    };
-  } catch (error) {
-    console.error("GitHub OAuth Error:", error.response?.data || error.message);
-    throw new AppError("GitHub OAuth failed", 500);
-  }
-};
-
-export const saveGithubIntegration = async (data) => {
-  const connection = await pool.getConnection();
-
-  const {
-    userId,
-    provider,
-    externalId,
-    name,
-    accessToken,
-    tokenType,
-    scope,
-    refreshToken,
-    expiresAt,
-    last_refreshed_at,
-  } = data;
-
-  try {
-    await connection.beginTransaction();
-
-    const exists = await Integration.sameIntegrationExists(
-      { userId, provider, externalId },
-      connection,
-    );
-
-    if (exists) {
-      const existingIntegration = await Integration.insertTokenProvider(
-        { userId, provider, externalId, name },
-        connection,
-      );
-
-      await Integration.insertOAuthToken(
-        {
-          integrationId: existingIntegration.insertId,
-          accessToken,
-          refreshToken: refreshToken ?? null,
-          tokenType: tokenType ?? null,
-          scope: scope ?? null,
-          expiresAt: expiresAt ?? null,
-          last_refreshed_at: last_refreshed_at ?? null,
-        },
-        connection,
-      );
-
-      await connection.commit();
-
-      return {
-        success: true,
-        message: "GitHub already connected. Token refreshed successfully.",
-        alreadyConnected: true,
-      };
-    }
-    const result = await Integration.insertTokenProvider(
-      {
-        userId,
-        provider,
-        externalId,
-        name,
-      },
-      connection,
-    );
-
-    const integrationId = result.insertId;
-
-    await Integration.insertOAuthToken(
-      {
-        integrationId,
-        accessToken,
-        refreshToken: refreshToken ?? null,
-        tokenType: tokenType ?? null,
-        scope: scope ?? null,
-        expiresAt: expiresAt ?? null,
-        last_refreshed_at: last_refreshed_at ?? null,
-      },
-      connection,
-    );
-
-    await connection.commit();
-
-    return {
-      success: true,
-      message: "GitHub integrated successfully",
-    };
-  } catch (error) {
-    await connection.rollback();
-    console.error(error.message);
-    throw new AppError("Something went wrong!", 500);
-  } finally {
-    connection.release();
-  }
+  return metadata;
 };

--- a/backend/src/services/integration/github/github.crud.service.js
+++ b/backend/src/services/integration/github/github.crud.service.js
@@ -1,78 +1,90 @@
-import axios from 'axios';
-import { Integration } from '../../../models/integration/integration.model.js';
-import { AppError } from '../../../utils/AppErrors.js';
+import { Integration } from "../../../models/integration/integration.model.js";
+import { AppError } from "../../../utils/AppErrors.js";
+import {
+  exchangeInstallationToken,
+  fetchInstallationMetadata,
+  fetchInstallationRepositories,
+} from "./githubApp.service.js";
+import { upsertGithubInstallation } from "./githubWebhook.service.js";
 
-const githubApi = axios.create({
-  baseURL: 'https://api.github.com',
-  timeout: 10000,
-  headers: {
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-  },
-});
+const isTokenUsable = (expiresAt) => {
+  if (!expiresAt) return false;
+  const bufferMs = 60 * 1000;
+  return new Date(expiresAt).getTime() - bufferMs > Date.now();
+};
 
-const getGithubMetadata = async (accessToken) => {
-  const headers = { Authorization: `Bearer ${accessToken}` };
+const getInstallationTokenForIntegration = async (userId, integration) => {
+  if (integration.access_token && isTokenUsable(integration.expires_at)) {
+    return {
+      token: integration.access_token,
+      expiresAt: new Date(integration.expires_at),
+    };
+  }
 
-  const [profileResponse, reposResponse] = await Promise.all([
-    githubApi.get('/user', { headers }),
-    githubApi.get('/user/repos', {
-      headers,
-      params: {
-        per_page: 100,
-        sort: 'updated',
-      },
-    }),
-  ]);
+  const { token, expiresAt } = await exchangeInstallationToken(integration.external_id);
 
-  const profile = profileResponse.data;
-  const repos = reposResponse.data || [];
+  await upsertGithubInstallation({
+    userId,
+    installationId: integration.external_id,
+    accountLogin: integration.name,
+    repositorySelection: integration.scope,
+    installationToken: token,
+    expiresAt,
+  });
 
-  return {
-    login: profile?.login || null,
-    avatar_url: profile?.avatar_url || null,
-    html_url: profile?.html_url || null,
-    repos: repos.map((repo) => ({
-      id: repo.id,
-      name: repo.name,
-      owner: repo.owner?.login || null,
-      full_name: repo.full_name,
-      private: repo.private,
-      default_branch: repo.default_branch,
-      html_url: repo.html_url,
-    })),
-  };
+  return { token, expiresAt };
 };
 
 export const getGithubIntegration = async (userId, provider) => {
-  const data = await Integration.getIntegration({ userId, provider });
+  const rows = await Integration.getIntegration({ userId, provider });
 
-  if (data.length === 0) {
+  if (rows.length === 0) {
     return {
       success: true,
-      message: 'No Integration exist.',
+      message: "No Integration exist.",
       data: [],
     };
   }
 
   try {
     const integrationsWithMetadata = await Promise.all(
-      data.map(async (integration) => ({
-        id: integration.id,
-        name: integration.name,
-        provider: integration.provider,
-        external_id: integration.external_id,
-        metadata: await getGithubMetadata(integration.access_token),
-      }))
+      rows.map(async (integration) => {
+        const { token } = await getInstallationTokenForIntegration(userId, integration);
+        const installationMetadata = await fetchInstallationMetadata(integration.external_id, token);
+        const repositories = await fetchInstallationRepositories(token);
+
+        await upsertGithubInstallation({
+          userId,
+          installationId: integration.external_id,
+          accountLogin: installationMetadata.account.login || integration.name,
+          repositorySelection: installationMetadata.repositorySelection,
+          installationToken: token,
+          expiresAt: integration.expires_at,
+        });
+
+        return {
+          id: integration.id,
+          name: integration.name,
+          provider: integration.provider,
+          installation_id: integration.external_id,
+          metadata: {
+            login: installationMetadata.account.login,
+            account_type: installationMetadata.account.type,
+            avatar_url: installationMetadata.account.avatarUrl,
+            repository_selection: installationMetadata.repositorySelection,
+            repositories,
+          },
+        };
+      }),
     );
 
     return {
       success: true,
-      message: 'All Integration Fetched.',
+      message: "All Integration Fetched.",
       data: integrationsWithMetadata,
     };
   } catch (error) {
-    console.error('GitHub Integration CRUD Error:', error.response?.data || error.message);
-    throw new AppError('Failed to fetch GitHub integration metadata', 500);
+    console.error("GitHub Integration CRUD Error:", error.response?.data || error.message);
+    throw new AppError("Failed to fetch GitHub integration metadata", 500);
   }
 };

--- a/backend/src/services/integration/github/githubApp.service.js
+++ b/backend/src/services/integration/github/githubApp.service.js
@@ -1,0 +1,95 @@
+import { githubApiClient } from "../../../utils/githubApiClient.util.js";
+import { generateGithubAppJwt } from "../../../utils/githubAppJwt.util.js";
+import { AppError } from "../../../utils/AppErrors.js";
+
+const githubAppHeaders = (jwt) => ({
+  Authorization: `Bearer ${jwt}`,
+});
+
+const installationHeaders = (token) => ({
+  Authorization: `Bearer ${token}`,
+});
+
+export const getGithubAppInstallUrl = (userId, workflowId) => {
+  const stateData = Buffer.from(JSON.stringify({ userId, workflowId })).toString("base64");
+
+  const baseInstallUrl = process.env.GITHUB_APP_INSTALL_URL
+    || (process.env.GITHUB_APP_NAME
+      ? `https://github.com/apps/${process.env.GITHUB_APP_NAME}/installations/new`
+      : null);
+
+  if (!baseInstallUrl) {
+    throw new AppError("Missing GITHUB_APP_INSTALL_URL or GITHUB_APP_NAME for GitHub App install redirect.", 500);
+  }
+
+  const url = new URL(baseInstallUrl);
+  url.searchParams.set("state", stateData);
+
+  return url.toString();
+};
+
+export const exchangeInstallationToken = async (installationId) => {
+  try {
+    const appJwt = generateGithubAppJwt();
+
+    const response = await githubApiClient.post(
+      `/app/installations/${installationId}/access_tokens`,
+      {},
+      { headers: githubAppHeaders(appJwt) },
+    );
+
+    return {
+      token: response.data?.token,
+      expiresAt: response.data?.expires_at ? new Date(response.data.expires_at) : null,
+    };
+  } catch (error) {
+    console.error("GitHub installation token exchange error:", error.response?.data || error.message);
+    throw new AppError("Failed to exchange GitHub App JWT for installation token.", 500);
+  }
+};
+
+export const fetchInstallationMetadata = async (installationId, installationToken) => {
+  try {
+    const response = await githubApiClient.get(`/app/installations/${installationId}`, {
+      headers: installationHeaders(installationToken),
+    });
+
+    const data = response.data;
+
+    return {
+      installationId: data?.id ? String(data.id) : null,
+      repositorySelection: data?.repository_selection || null,
+      account: {
+        login: data?.account?.login || null,
+        type: data?.account?.type || null,
+        avatarUrl: data?.account?.avatar_url || null,
+        accountId: data?.account?.id ? String(data.account.id) : null,
+      },
+    };
+  } catch (error) {
+    console.error("GitHub installation metadata error:", error.response?.data || error.message);
+    throw new AppError("Failed to fetch GitHub installation metadata.", 500);
+  }
+};
+
+export const fetchInstallationRepositories = async (installationToken) => {
+  try {
+    const response = await githubApiClient.get("/installation/repositories", {
+      headers: installationHeaders(installationToken),
+      params: {
+        per_page: 100,
+      },
+    });
+
+    const repositories = response.data?.repositories || [];
+
+    return repositories.map((repo) => ({
+      id: repo.id,
+      name: repo.name,
+      full_name: repo.full_name,
+    }));
+  } catch (error) {
+    console.error("GitHub repositories fetch error:", error.response?.data || error.message);
+    throw new AppError("Failed to fetch repositories for GitHub installation.", 500);
+  }
+};

--- a/backend/src/services/integration/github/githubWebhook.service.js
+++ b/backend/src/services/integration/github/githubWebhook.service.js
@@ -1,0 +1,114 @@
+import pool from "../../../config/db.js";
+import { Integration } from "../../../models/integration/integration.model.js";
+import { AppError } from "../../../utils/AppErrors.js";
+import {
+  exchangeInstallationToken,
+  fetchInstallationMetadata,
+  fetchInstallationRepositories,
+} from "./githubApp.service.js";
+
+const resolveInternalUserId = async (payload, client) => {
+  const accountId = payload?.installation?.account?.id || payload?.account?.id;
+
+  if (!accountId) {
+    throw new AppError("Unable to resolve GitHub account id from installation payload.", 400);
+  }
+
+  const mapped = await Integration.getIntegrationByProviderAndExternalId(
+    { provider: "github", externalId: String(accountId) },
+    client,
+  );
+
+  if (!mapped?.user_id) {
+    throw new AppError(
+      "GitHub account is not linked to a platform user yet. Connect GitHub from the app before installation.",
+      400,
+    );
+  }
+
+  return mapped.user_id;
+};
+
+export const upsertGithubInstallation = async ({
+  userId,
+  installationId,
+  accountLogin,
+  repositorySelection,
+  installationToken,
+  expiresAt,
+}) => {
+  const connection = await pool.getConnection();
+
+  try {
+    await connection.beginTransaction();
+
+    const providerRow = await Integration.insertTokenProvider(
+      {
+        userId,
+        provider: "github",
+        externalId: String(installationId),
+        name: accountLogin || `github-installation-${installationId}`,
+      },
+      connection,
+    );
+
+    await Integration.insertOAuthToken(
+      {
+        integrationId: providerRow.insertId,
+        accessToken: installationToken || null,
+        refreshToken: null,
+        tokenType: "installation",
+        scope: repositorySelection || null,
+        expiresAt: expiresAt || null,
+        last_refreshed_at: new Date(),
+      },
+      connection,
+    );
+
+    await connection.commit();
+
+    return providerRow.insertId;
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    connection.release();
+  }
+};
+
+export const processGithubInstallationWebhook = async (payload) => {
+  const installationId = payload?.installation?.id;
+
+  if (!installationId) {
+    throw new AppError("Missing installation.id in GitHub webhook payload.", 400);
+  }
+
+  const connection = await pool.getConnection();
+  let userId;
+
+  try {
+    userId = await resolveInternalUserId(payload, connection);
+  } finally {
+    connection.release();
+  }
+
+  const { token, expiresAt } = await exchangeInstallationToken(String(installationId));
+  const metadata = await fetchInstallationMetadata(String(installationId), token);
+  const repositories = await fetchInstallationRepositories(token);
+
+  await upsertGithubInstallation({
+    userId,
+    installationId,
+    accountLogin: metadata.account.login,
+    repositorySelection: metadata.repositorySelection,
+    installationToken: token,
+    expiresAt,
+  });
+
+  return {
+    installationId: String(installationId),
+    repositorySelection: metadata.repositorySelection,
+    account: metadata.account,
+    repositories,
+  };
+};

--- a/backend/src/services/integration/utils/integration.service.js
+++ b/backend/src/services/integration/utils/integration.service.js
@@ -6,66 +6,59 @@ import { getSlackIntegration } from "../slack/slack.crud.service.js";
 import { getGoogleAuthUrl, handleGoogleCallback, saveGoogleIntegration } from "../google/google.auth.service.js";
 import { getGoogleIntegration } from "../google/google.crud.service.js";
 
-import { getGithubAuthUrl, handleGithubCallback, saveGithubIntegration } from "../github/github.auth.service.js";
 import { getGithubIntegration } from "../github/github.crud.service.js";
 
 const getProviderUrl = {
-    slack: getSlackAuthUrl,
-    googleDrive: getGoogleAuthUrl,
-    gmail: getGoogleAuthUrl,
-    googleForm: getGoogleAuthUrl,
-    github: getGithubAuthUrl,
-}
+  slack: getSlackAuthUrl,
+  googleDrive: getGoogleAuthUrl,
+  gmail: getGoogleAuthUrl,
+  googleForm: getGoogleAuthUrl,
+};
 
 const handleCallback = {
-    slack: handleSlackCallback,
-    googleDrive: handleGoogleCallback,
-    gmail: handleGoogleCallback,
-    googleForm: handleGoogleCallback,
-    github: handleGithubCallback,
-}
+  slack: handleSlackCallback,
+  googleDrive: handleGoogleCallback,
+  gmail: handleGoogleCallback,
+  googleForm: handleGoogleCallback,
+};
 
 const handleInsertToken = {
-    slack: saveSlackIntegration,
-    googleDrive: saveGoogleIntegration,
-    gmail: saveGoogleIntegration,
-    googleForm: saveGoogleIntegration,
-    github: saveGithubIntegration,
-}
+  slack: saveSlackIntegration,
+  googleDrive: saveGoogleIntegration,
+  gmail: saveGoogleIntegration,
+  googleForm: saveGoogleIntegration,
+};
 
 const handleCRUD = {
-    slack: getSlackIntegration,
-    googleDrive: getGoogleIntegration,
-    gmail: getGoogleIntegration,
-    googleForm: getGoogleIntegration,
-    github: getGithubIntegration,
-}
+  slack: getSlackIntegration,
+  googleDrive: getGoogleIntegration,
+  gmail: getGoogleIntegration,
+  googleForm: getGoogleIntegration,
+  github: getGithubIntegration,
+};
 
-
-export const integrationOAuthGetUrl = async (provider, workflowId, userId) => { 
-    const fn = getProviderUrl[provider];
-    if (!fn) throw new AppError("Unsupported Provider!", 400);
-    return await fn(userId, workflowId, provider);
-}
-
+export const integrationOAuthGetUrl = async (provider, workflowId, userId) => {
+  const fn = getProviderUrl[provider];
+  if (!fn) throw new AppError("Unsupported Provider!", 400);
+  return await fn(userId, workflowId, provider);
+};
 
 export const integrationHandleOAuthCallback = async (provider, code, userId) => {
-    const fn = handleCallback[provider];
-    if (!fn) throw new AppError("Unsupported Provider!", 400);
-    return await fn(code, userId);
-}
-
+  const fn = handleCallback[provider];
+  if (!fn) throw new AppError("Unsupported Provider!", 400);
+  return await fn(code, userId);
+};
 
 export const integrationInsertOAuthToken = async (provider, data) => {
-    const fn = handleInsertToken[provider];
-    if (!fn) throw new AppError("Unsupported Provider!", 400);
-    return await fn(data);
-}
+  const fn = handleInsertToken[provider];
+  if (!fn) throw new AppError("Unsupported Provider!", 400);
+  return await fn(data);
+};
 
 export const integrationCRUD = async (userId, provider) => {
-    const fn = handleCRUD[provider];
-    if (!fn) {
-        throw new AppError("Unsupported Provider!", 400);
-    }
-    return await fn(userId, provider);
-}
+  const fn = handleCRUD[provider];
+  if (!fn) {
+    throw new AppError("Unsupported Provider!", 400);
+  }
+  return await fn(userId, provider);
+};

--- a/backend/src/utils/githubApiClient.util.js
+++ b/backend/src/utils/githubApiClient.util.js
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+export const githubApiClient = axios.create({
+  baseURL: "https://api.github.com",
+  timeout: 15000,
+  headers: {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  },
+});

--- a/backend/src/utils/githubAppJwt.util.js
+++ b/backend/src/utils/githubAppJwt.util.js
@@ -1,0 +1,29 @@
+import jwt from "jsonwebtoken";
+import { AppError } from "./AppErrors.js";
+
+const normalizePrivateKey = (privateKey) => {
+  if (!privateKey) return "";
+  return privateKey.replace(/\\n/g, "\n");
+};
+
+export const generateGithubAppJwt = () => {
+  const appId = process.env.GITHUB_APP_ID;
+  const privateKeyRaw = process.env.GITHUB_APP_PRIVATE_KEY;
+  const privateKey = normalizePrivateKey(privateKeyRaw);
+
+  if (!appId || !privateKey) {
+    throw new AppError("Missing GitHub App credentials (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY).", 500);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  return jwt.sign(
+    {
+      iat: now - 60,
+      exp: now + 9 * 60,
+      iss: appId,
+    },
+    privateKey,
+    { algorithm: "RS256" },
+  );
+};


### PR DESCRIPTION
### Motivation

- Replace the legacy OAuth-style GitHub integration with a GitHub App architecture that uses installation tokens instead of user OAuth access tokens. 
- Ensure we persist the `installation_id` received via the `installation` webhook and record `repository_selection` (`all` / `selected`) for correct feature behavior.
- Centralize GitHub App logic (JWT generation, installation token exchange, metadata and repo fetching) into services for a cleaner controller/service separation.

### Description

- Introduced GitHub App utilities: `backend/src/utils/githubAppJwt.util.js` for JWT generation and `backend/src/utils/githubApiClient.util.js` as an Axios wrapper for GitHub API calls.
- Added `backend/src/services/integration/github/githubApp.service.js` to generate App JWTs, exchange JWTs for installation access tokens, fetch installation metadata, and list installation repositories.
- Added `backend/src/services/integration/github/githubWebhook.service.js` to process `installation` webhooks, resolve the internal `user_id` mapping, and upsert installation records into the existing integrations schema.
- Reworked CRUD/read flow in `backend/src/services/integration/github/github.crud.service.js` to obtain installation tokens (exchanging the App JWT when needed), fetch account metadata and repositories, and return `repository_selection` and repository list.
- Replaced OAuth-specific GitHub code paths: created controller-only endpoints `backend/src/controllers/integration/github.auth.controller.js` (install redirect + setup callback) and `backend/src/controllers/integration/github.webhook.controller.js` for webhook handling, and updated routes in `backend/src/routes/integration/integration.auth.routes.js` and `backend/src/routes/webhook.route.js`.
- Updated integration utilities in `backend/src/services/integration/utils/integration.service.js` to stop treating GitHub as an OAuth provider and to rely on the new GitHub CRUD/service flow.
- Expanded `backend/src/models/integration/integration.model.js` with a `getIntegrationByProviderAndExternalId` lookup to support mapping migrated OAuth GitHub account IDs to internal users; persisted installation state by storing `installation_id` in `integrations.external_id`, `repository_selection` in `integration_accounts.scope`, and temporary installation token in `integration_accounts.access_token` with `token_type = "installation"`.
- Removed the previous dummy logging webhook logic from the generic webhook controller so GitHub installation events are handled by the dedicated webhook controller.

### Testing

- Ran static syntax checks with `node --check` on the new/modified modules: `src/services/integration/github/githubApp.service.js`, `src/services/integration/github/githubWebhook.service.js`, `src/services/integration/github/github.crud.service.js`, `src/controllers/integration/github.webhook.controller.js`, `src/controllers/integration/github.auth.controller.js`, `src/routes/webhook.route.js`, `src/routes/integration/integration.auth.routes.js`, `src/services/integration/utils/integration.service.js`, and `src/models/integration/integration.model.js`; these checks completed successfully.
- No automated unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37a3a7dbc83279b5940922835aeb9)