### PR TITLE
Add execution history tracking and Executions dashboard

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -19,6 +19,7 @@ import webhooks from "./src/routes/webhook.route.js";
 import aiIntegrationRoutes from "./src/routes/aiIntegration.routes.js";
 
 import integrationRoutes from "./src/routes/integration/integration.auth.routes.js"
+import executionRoutes from "./src/routes/executions.routes.js"
 
 const app = express();
 await connectDB();
@@ -60,6 +61,7 @@ app.use("/api/webhook", webhooks);
 app.use("/api/ai/integration", aiIntegrationRoutes);
 app.use("/api/integration", integrationRoutes);
 app.use("/api/user", profileRoutes);
+app.use("/api/executions", executionRoutes);
 
 
 app.use((err, req, res, next) => {

--- a/backend/src/controllers/execution.controllers.js
+++ b/backend/src/controllers/execution.controllers.js
@@ -1,0 +1,32 @@
+import { getExecutionDetail, getUserExecutions } from "../services/execution/execution.repositories.js";
+
+export const executionList = async (req, res) => {
+  try {
+    const result = await getUserExecutions(req.user);
+    res.status(200).json({ success: true, executions: result.executions });
+  } catch (error) {
+    console.error(error);
+    res.status(error.statusCode || 500).json({ success: false, message: error.message || "Internal Server Error" });
+  }
+};
+
+export const executionDetail = async (req, res) => {
+  try {
+    const executionId = Number(req.params.id);
+
+    if (!executionId) {
+      return res.status(400).json({ success: false, message: "Execution id is required" });
+    }
+
+    const execution = await getExecutionDetail(req.user, executionId);
+
+    if (!execution) {
+      return res.status(404).json({ success: false, message: "Execution not found" });
+    }
+
+    res.status(200).json({ success: true, execution });
+  } catch (error) {
+    console.error(error);
+    res.status(error.statusCode || 500).json({ success: false, message: error.message || "Internal Server Error" });
+  }
+};

--- a/backend/src/inngest/functions.js
+++ b/backend/src/inngest/functions.js
@@ -6,21 +6,81 @@ import { getNodeExecutor } from "../services/workflow/nodeExecutor/executorRegis
 import { httpRequestChannel } from "./workflowStatus.js";
 //import { processWorkflowPolling } from "../services/pollingService.js";
 import { processWorkflowPolling } from "../services/polling/polling.service.js";
+import { Execution } from "../models/execution.model.js";
 
 export const executeWorkflow = inngest.createFunction(
-  { id: "execute-workflow" },
-  { event: "workflow/execute",
+  {
+    id: "execute-workflow",
+    onFailure: async ({ event, error }) => {
+      const workflowId = event?.data?.workflowId;
+      const inngestId = event?.id;
+
+      if (!workflowId || !inngestId) {
+        return;
+      }
+
+      try {
+        const userRecord = await Workflow.getUserId({ workflowId });
+        const outputData = event?.data?.initialData || null;
+
+        const result = await Execution.markFailure({
+          inngestId,
+          workflowId,
+          errorMsg: error?.message || "Execution failed after retries",
+          output: outputData,
+        });
+
+        if (result?.affectedRows === 0 && userRecord?.user_id) {
+          await Execution.create({
+            inngestId,
+            userId: userRecord.user_id,
+            workflowId,
+            status: "failed",
+            output: outputData,
+          });
+
+          await Execution.markFailure({
+            inngestId,
+            workflowId,
+            errorMsg: error?.message || "Execution failed after retries",
+            output: outputData,
+          });
+        }
+      } catch (failureError) {
+        console.error("Failed to persist execution failure", failureError);
+      }
+    },
+  },
+  {
+    event: "workflow/execute",
     channel: [httpRequestChannel()],
   },
 
   async ({ event, step, publish }) => {
     const workflowId = event.data.workflowId;
+    const inngestId = event.id;
+
     if (!workflowId) {
       throw new NonRetriableError("Workflow Id is missing!");
     }
 
-    const sortedNodes = await step.run("prepare-workflow", async () => {
+    const userId = await step.run("find-userId", async () => {
+      const user = await Workflow.getUserId({ workflowId });
+      return user.user_id;
+    });
 
+    await step.run("store-execution-start", async () => {
+      await Execution.create({
+        inngestId,
+        userId,
+        workflowId,
+        status: "running",
+        output: event.data.initialData || {},
+      });
+      return true;
+    });
+
+    const sortedNodes = await step.run("prepare-workflow", async () => {
       const workflowGraph = await Workflow.getWorkflowGraph({ workflowId });
 
       try {
@@ -29,12 +89,6 @@ export const executeWorkflow = inngest.createFunction(
       } catch (error) {
         throw new NonRetriableError(error.message || "Invalid workflow!");
       }
-
-    });
-
-    const userId = await step.run("find-userId", async () =>{
-      const userId = await Workflow.getUserId({workflowId});
-      return userId.user_id;
     });
 
     let context = event.data.initialData || {};
@@ -44,24 +98,30 @@ export const executeWorkflow = inngest.createFunction(
 
       const nodeExecutor = getNodeExecutor(triggerType);
       const response = await step.run(`node-${node.id}`, async () => {
-       
         return await nodeExecutor({
           data: node.data,
           nodeId: node.id,
           context,
           userId,
-          publish
+          publish,
         });
-      });          
-      
-      context[node?.data?.config?.variable || node.id] = response;    // there is a possibility that variable name is same, in that case we need uinique variable names or override the previous one, for now we will override it.
+      });
+
+      context[node?.data?.config?.variable || node.id] = response;
     }
 
-    //console.log(context);
+    await step.run("store-execution-success", async () => {
+      await Execution.markSuccess({
+        inngestId,
+        workflowId,
+        output: context,
+      });
+      return true;
+    });
+
     return { workflowId, result: context };
   },
 );
-
 
 export const pollWorkflowTriggers = inngest.createFunction(
   { id: "poll-workflow-triggers" },
@@ -74,5 +134,5 @@ export const pollWorkflowTriggers = inngest.createFunction(
     });
 
     return result;
-  }
+  },
 );

--- a/backend/src/models/execution.model.js
+++ b/backend/src/models/execution.model.js
@@ -1,0 +1,78 @@
+import pool from "../config/db.js";
+import { AppError } from "../utils/AppErrors.js";
+
+const query = async (sql, params = [], client = pool) => {
+  try {
+    const [rows] = await client.execute(sql, params);
+    return rows;
+  } catch (err) {
+    console.error("❌ DB Error (executions):", err.message);
+    throw new AppError("Database query failed: Execution Model", 500);
+  }
+};
+
+const safeJson = (value) => {
+  if (value === undefined) return null;
+  return JSON.stringify(value);
+};
+
+export const Execution = {
+  create: async (
+    { inngestId, userId, workflowId, status = "running", startAt = new Date(), attempt = 1, output = null },
+    client = pool,
+  ) => {
+    return query(
+      `INSERT INTO executions (inngest_id, user_id, workflow_id, status, start_at, attempt, output)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [inngestId, userId, workflowId, status, startAt, attempt, safeJson(output)],
+      client,
+    );
+  },
+
+  markSuccess: async ({ inngestId, workflowId, output = {} }, client = pool) => {
+    return query(
+      `UPDATE executions
+       SET status = 'success', completed_at = NOW(), output = ?, error_msg = NULL
+       WHERE inngest_id = ? AND workflow_id = ?`,
+      [safeJson(output), inngestId, workflowId],
+      client,
+    );
+  },
+
+  markFailure: async ({ inngestId, workflowId, errorMsg, output = null }, client = pool) => {
+    return query(
+      `UPDATE executions
+       SET status = 'failed', completed_at = NOW(), error_msg = ?, output = ?
+       WHERE inngest_id = ? AND workflow_id = ?`,
+      [errorMsg || "Workflow execution failed", safeJson(output), inngestId, workflowId],
+      client,
+    );
+  },
+
+  listByUser: async ({ userId }, client = pool) => {
+    return query(
+      `SELECT e.id, e.inngest_id, e.workflow_id, e.status, e.start_at, e.completed_at, e.updated_at, e.attempt, e.error_msg,
+              w.name AS workflow_name
+       FROM executions e
+       INNER JOIN workflows w ON e.workflow_id = w.id
+       WHERE e.user_id = ?
+       ORDER BY e.updated_at DESC`,
+      [userId],
+      client,
+    );
+  },
+
+  getById: async ({ id, userId }, client = pool) => {
+    const rows = await query(
+      `SELECT e.*, w.name AS workflow_name
+       FROM executions e
+       INNER JOIN workflows w ON e.workflow_id = w.id
+       WHERE e.id = ? AND e.user_id = ?
+       LIMIT 1`,
+      [id, userId],
+      client,
+    );
+
+    return rows[0] || null;
+  },
+};

--- a/backend/src/routes/executions.routes.js
+++ b/backend/src/routes/executions.routes.js
@@ -1,0 +1,11 @@
+import express from "express";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { executionDetail, executionList } from "../controllers/execution.controllers.js";
+
+const router = express.Router();
+
+router.use(authMiddleware);
+router.get("/", executionList);
+router.get("/:id", executionDetail);
+
+export default router;

--- a/backend/src/services/execution/execution.repositories.js
+++ b/backend/src/services/execution/execution.repositories.js
@@ -1,0 +1,13 @@
+import { Execution } from "../../models/execution.model.js";
+
+export const getUserExecutions = async (userData) => {
+  const userId = userData.userId;
+  const executions = await Execution.listByUser({ userId });
+  return { executions };
+};
+
+export const getExecutionDetail = async (userData, executionId) => {
+  const userId = userData.userId;
+  const execution = await Execution.getById({ id: executionId, userId });
+  return execution;
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,7 @@ import EditIntegrationForm from './components/aiIntegrations/EditIntegrationForm
 
 // Test Route
 import Test from './pages/Test'
+import ExecutionMain from './components/executions/ExecutionMain';
 
 function App() {
 
@@ -66,6 +67,8 @@ function App() {
                   <Route path="add/new/apikey" element={<AddIntegrationForm />} />
                   <Route path="edit/:provider/apikey" element={<EditIntegrationForm />} />
                 </Route>
+
+                <Route path="/executions" element={<ExecutionMain />} />
 
                 <Route path="/test" element={<Test />} />
 

--- a/frontend/src/api/execution.api.js
+++ b/frontend/src/api/execution.api.js
@@ -1,0 +1,11 @@
+import api from "@/utils/axiox";
+
+export const getExecutions = async () => {
+  const res = await api.get("/executions");
+  return res.data;
+};
+
+export const getExecutionDetail = async (executionId) => {
+  const res = await api.get(`/executions/${executionId}`);
+  return res.data;
+};

--- a/frontend/src/components/common/SideBar.jsx
+++ b/frontend/src/components/common/SideBar.jsx
@@ -27,7 +27,7 @@ const Sidebar = () => {
     {name: "Home", to: "/home", icon: faHouse},
     {name: "Workflow", to: "/workflow", icon: faMicrochip},
     {name: "AI-Integrations", to: "/ai/integrations", icon: faCodeMerge}, 
-    {name: "Runs", to: "/runs", icon: faCirclePlay},
+    {name: "Executions", to: "/executions", icon: faCirclePlay},
     {name: "Logs", to: "/logs", icon: faBook},
     {name: "Webhooks", to: "/webhooks", icon: faCircleNodes},
     {name: "test", to: "/test", icon: faRobot},

--- a/frontend/src/components/executions/ExecutionMain.jsx
+++ b/frontend/src/components/executions/ExecutionMain.jsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from "react";
+import { useExecutionDetail, useExecutions } from "@/hooks/useExecutionApi";
+
+const statusStyle = {
+  pending: "bg-yellow-500/15 text-yellow-300 border border-yellow-500/30",
+  running: "bg-blue-500/15 text-blue-300 border border-blue-500/30",
+  success: "bg-emerald-500/15 text-emerald-300 border border-emerald-500/30",
+  failed: "bg-red-500/15 text-red-300 border border-red-500/30",
+};
+
+const formatDate = (value) => {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+};
+
+const prettyJson = (value) => {
+  if (value === null || value === undefined) return "No output available";
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+
+  return JSON.stringify(value, null, 2);
+};
+
+const ExecutionMain = () => {
+  const [selectedId, setSelectedId] = useState(null);
+  const { data, isPending, isError } = useExecutions();
+
+  const executions = data?.executions || [];
+  const selectedFallback = useMemo(() => {
+    if (!selectedId) return executions[0]?.id || null;
+    return selectedId;
+  }, [selectedId, executions]);
+
+  const {
+    data: detailData,
+    isPending: detailPending,
+  } = useExecutionDetail(selectedFallback);
+
+  if (isPending) {
+    return <div className="text-zinc-300 p-6">Loading executions...</div>;
+  }
+
+  if (isError) {
+    return <div className="text-red-300 p-6">Failed to load executions.</div>;
+  }
+
+  if (!executions.length) {
+    return (
+      <div className="rounded-xl border border-white/10 bg-[#0b0b0b] p-8 text-zinc-300">
+        No executions found yet. Run any workflow to see history.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 h-full">
+      <div className="xl:col-span-1 rounded-2xl border border-white/10 bg-[#0b0b0b] p-4 space-y-3 overflow-y-auto max-h-[calc(100vh-170px)]">
+        <h2 className="text-lg font-bold text-white">Execution History</h2>
+        {executions.map((item) => {
+          const active = selectedFallback === item.id;
+          return (
+            <button
+              key={item.id}
+              onClick={() => setSelectedId(item.id)}
+              className={`w-full text-left rounded-xl p-4 border transition-all ${
+                active
+                  ? "bg-zinc-900 border-blue-500/60"
+                  : "bg-black/40 border-white/10 hover:border-zinc-500"
+              }`}
+            >
+              <div className="flex justify-between items-center gap-2">
+                <p className="text-white font-semibold truncate">{item.workflow_name}</p>
+                <span className={`px-2 py-1 rounded-md text-xs font-semibold ${statusStyle[item.status] || "bg-zinc-700 text-zinc-100"}`}>
+                  {item.status}
+                </span>
+              </div>
+              <p className="text-xs text-zinc-400 mt-2">Workflow: {item.workflow_id}</p>
+              <p className="text-xs text-zinc-500 mt-1">Updated: {formatDate(item.updated_at)}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="xl:col-span-2 rounded-2xl border border-white/10 bg-[#0b0b0b] p-6 overflow-y-auto max-h-[calc(100vh-170px)]">
+        {detailPending ? (
+          <p className="text-zinc-400">Loading execution detail...</p>
+        ) : (
+          <>
+            <div className="flex items-start justify-between mb-6">
+              <div>
+                <h3 className="text-2xl font-bold text-white">{detailData?.execution?.workflow_name}</h3>
+                <p className="text-zinc-400 text-sm mt-1">Execution #{detailData?.execution?.id}</p>
+              </div>
+              <span className={`px-3 py-1 rounded-lg text-sm font-semibold ${statusStyle[detailData?.execution?.status]}`}>
+                {detailData?.execution?.status}
+              </span>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-6">
+              <div className="rounded-lg border border-white/10 bg-black/40 p-3 text-sm text-zinc-300">Start: {formatDate(detailData?.execution?.start_at)}</div>
+              <div className="rounded-lg border border-white/10 bg-black/40 p-3 text-sm text-zinc-300">Completed: {formatDate(detailData?.execution?.completed_at)}</div>
+              <div className="rounded-lg border border-white/10 bg-black/40 p-3 text-sm text-zinc-300">Attempt: {detailData?.execution?.attempt}</div>
+              <div className="rounded-lg border border-white/10 bg-black/40 p-3 text-sm text-zinc-300 truncate">Inngest Id: {detailData?.execution?.inngest_id}</div>
+            </div>
+
+            {detailData?.execution?.error_msg ? (
+              <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 mb-4">
+                <p className="text-red-300 font-semibold mb-1">Error</p>
+                <p className="text-red-200 text-sm whitespace-pre-wrap">{detailData.execution.error_msg}</p>
+              </div>
+            ) : null}
+
+            <div>
+              <p className="text-zinc-300 font-semibold mb-2">Output</p>
+              <pre className="bg-black/60 border border-white/10 rounded-xl p-4 text-xs text-zinc-200 overflow-auto whitespace-pre-wrap break-words">
+                {prettyJson(detailData?.execution?.output)}
+              </pre>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ExecutionMain;

--- a/frontend/src/hooks/useExecutionApi.js
+++ b/frontend/src/hooks/useExecutionApi.js
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { getExecutionDetail, getExecutions } from "@/api/execution.api";
+
+export const useExecutions = () => {
+  return useQuery({
+    queryKey: ["executions"],
+    queryFn: getExecutions,
+    staleTime: 5 * 1000,
+  });
+};
+
+export const useExecutionDetail = (executionId) => {
+  return useQuery({
+    queryKey: ["executions", executionId],
+    queryFn: () => getExecutionDetail(executionId),
+    enabled: Boolean(executionId),
+  });
+};


### PR DESCRIPTION
### Motivation
- Persist workflow run lifecycle so execution outputs, errors and timestamps are stored in the new `executions` table for observability and debugging. 
- Ensure failures reported by Inngest are recorded via `onFailure` so failed runs are visible and searchable. 
- Expose execution history to users in the frontend with a dark-themed UI and a details view to inspect outputs and errors.

### Description
- Added a new backend `Execution` model with `create`, `markSuccess`, `markFailure`, `listByUser`, and `getById` methods to read/write the `executions` table (`backend/src/models/execution.model.js`).
- Enhanced the Inngest workflow handler in `backend/src/inngest/functions.js` to create a `running` execution at start, persist final `output` on success, and persist failure details in `onFailure` (including fallback creation if no row exists).
- Implemented execution service/repository and controllers with routes `GET /api/executions` and `GET /api/executions/:id`, and wired the routes into `backend/app.js` (`backend/src/services/execution/*`, `backend/src/controllers/execution.controllers.js`, `backend/src/routes/executions.routes.js`).
- Added frontend API client, React Query hooks, a new dark-themed `ExecutionMain` page with clickable execution cards and a detail panel showing status, timestamps, attempt, inngest id, error, and full output JSON, and registered the route at `/executions`; also renamed sidebar item from `Runs` to `Executions` (`frontend/src/api/execution.api.js`, `frontend/src/hooks/useExecutionApi.js`, `frontend/src/components/executions/ExecutionMain.jsx`, `frontend/src/components/common/SideBar.jsx`, `frontend/src/App.jsx`).

### Testing
- Built the frontend using `cd frontend && npm run build` and the production build completed successfully. 
- Performed JavaScript syntax checks with `node --check` on changed backend modules (`backend/src/inngest/functions.js`, `backend/src/controllers/execution.controllers.js`, `backend/src/routes/executions.routes.js`, `backend/src/models/execution.model.js`) and they passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d655ef848327bb648323a8326ebc)