### PR TITLE
Add workflow run stats tracking and workflow card metrics

### DIFF
--- a/backend/src/inngest/functions.js
+++ b/backend/src/inngest/functions.js
@@ -77,6 +77,8 @@ export const executeWorkflow = inngest.createFunction(
         status: "running",
         output: event.data.initialData || {},
       });
+
+      await Workflow.incrementWorkflowRuns({ workflowId });
       return true;
     });
 

--- a/backend/src/models/workflow.model.js
+++ b/backend/src/models/workflow.model.js
@@ -56,7 +56,23 @@ export const Workflow = {
 
     getWorkflowMetadata: async ({userId}, client = pool) => {
         const rows = await query(
-            "SELECT * FROM workflows WHERE user_id = ?",
+            `SELECT 
+                w.*,
+                COALESCE(exec_stats.success_runs, 0) AS success_runs,
+                CASE 
+                    WHEN w.runs = 0 THEN NULL
+                    ELSE ROUND((COALESCE(exec_stats.success_runs, 0) / w.runs) * 100, 0)
+                END AS success_rate
+            FROM workflows w
+            LEFT JOIN (
+                SELECT workflow_id, user_id, COUNT(*) AS success_runs
+                FROM executions
+                WHERE status = 'success'
+                GROUP BY workflow_id, user_id
+            ) exec_stats
+                ON exec_stats.workflow_id = w.id
+                AND exec_stats.user_id = w.user_id
+            WHERE w.user_id = ?`,
             [userId],
             client
         );
@@ -158,6 +174,19 @@ export const Workflow = {
             [triggerType, configJson, lastChecked, userId, workflowId, nodeId],
             client
         );
+    },
+
+    incrementWorkflowRuns: async ({ workflowId }, client = pool) => {
+        const rows = await query(
+            `UPDATE workflows
+            SET runs = COALESCE(runs, 0) + 1,
+                last_runs_time = NOW()
+            WHERE id = ?`,
+            [workflowId],
+            client
+        );
+
+        return rows;
     },
 
     getPollingTriggers: async (client = pool) => {

--- a/frontend/src/components/workflow/WorkflowCard.jsx
+++ b/frontend/src/components/workflow/WorkflowCard.jsx
@@ -26,9 +26,9 @@ const WorkflowCard = ({data, onClick}) => {
     },
     createdAt: data.created_at,
     updatedAt: data.updated_at,
-    runs: 127,
-    success: "98%",
-    lastRun: "2h ago",
+    runs: Number(data.runs ?? 0),
+    success: data.success_rate === null || data.success_rate === undefined ? "-" : `${data.success_rate}%`,
+    lastRun: data.last_runs_time,
   };
 
   const STATUS_STYLES = {
@@ -50,6 +50,35 @@ const WorkflowCard = ({data, onClick}) => {
       hour: "2-digit",
       minute: "2-digit",
     }).format(date);
+  };
+
+  const formatRelativeTime = (isoString) => {
+    if (!isoString) return "-";
+
+    const lastRunDate = new Date(isoString);
+    if (isNaN(lastRunDate.getTime())) return "-";
+
+    const now = new Date();
+    const diffMs = now.getTime() - lastRunDate.getTime();
+
+    if (diffMs < 0) return "-";
+
+    const totalMinutes = Math.floor(diffMs / (1000 * 60));
+    const days = Math.floor(totalMinutes / (60 * 24));
+    const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+    const minutes = totalMinutes % 60;
+
+    if (days > 0) {
+      return hours > 0 ? `${days}d ${hours}h ago` : `${days}d ago`;
+    }
+
+    if (hours > 0) {
+      return minutes > 0 ? `${hours}h ${minutes}m ago` : `${hours}h ago`;
+    }
+
+    if (minutes <= 0) return "just now";
+
+    return `${minutes}m ago`;
   };
 
 
@@ -115,7 +144,7 @@ const WorkflowCard = ({data, onClick}) => {
             <div className="text-[9px] text-gray-600 uppercase font-black"> Success </div>
           </div>
           <div className="text-center">
-            <div className="text-sm font-bold text-gray-400">{workflow.lastRun}</div>
+            <div className="text-sm font-bold text-gray-400">{workflow.runs === 0 ? "-" : formatRelativeTime(workflow.lastRun)}</div>
             <div className="text-[9px] text-gray-600 uppercase font-black">Last Run</div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Persist per-workflow run counters and last-run timestamp so the UI can show how many times a workflow ran and when it last ran. 
- Surface execution success metrics for each workflow so users can see a success rate on the workflow list cards. 
- Replace hardcoded metrics in the workflow cards with live values from the backend and display a human-friendly relative last-run time.

### Description
- Added a metadata query in `Workflow.getWorkflowMetadata` that returns `success_runs` and a computed `success_rate` per workflow, while returning all existing workflow fields. 
- Implemented `Workflow.incrementWorkflowRuns({ workflowId })` which increments `workflows.runs` and updates `workflows.last_runs_time` on each execution start. 
- Wired the increment to execution startup by calling `Workflow.incrementWorkflowRuns` from the execution flow in `backend/src/inngest/functions.js` during `store-execution-start`. 
- Updated `frontend/src/components/workflow/WorkflowCard.jsx` to read `runs`, `success_rate`, and `last_runs_time` from API data, format the success as `%` or `-`, and render a relative-time string (e.g. `2h 4m ago`) with `-` shown when `runs === 0`.

### Testing
- Built the frontend with `npm --prefix frontend run build` and the build completed successfully. 
- Performed static checks with `node --check backend/src/inngest/functions.js` and `node --check backend/src/models/workflow.model.js`, both passed. 
- Ran `npm --prefix backend run test`, which failed because the backend package contains the placeholder test script that intentionally exits with an error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e527e065a88327826098f81e7d2c25)