### PR TITLE
Add profile page + session-backed auth endpoints and ProtectedRoute verification

### DIFF
--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,4 +1,4 @@
-import { signupService, loginService } from '../services/auth/auth.service.js';
+import { signupService, loginService, getSessionUserService } from '../services/auth/auth.service.js';
 
 export const signup = async (req, res) => {
     try {
@@ -48,4 +48,35 @@ export const login = async (req, res) => {
             message: error.message || "Internal Server Error"
         });
     }
-}; 
+};
+
+export const me = async (req, res) => {
+    try {
+        const user = await getSessionUserService(req.user.userId);
+
+        res.status(200).json({
+            userId: user.id,
+            username: user.username,
+            email: user.email,
+        });
+    } catch (error) {
+        console.error("Session Error --> : ", error.message);
+        res.status(error.statusCode || 500).json({
+            success: false,
+            message: error.message || "Internal Server Error"
+        });
+    }
+};
+
+export const logout = async (req, res) => {
+    res.clearCookie("token", {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: "lax"
+    });
+
+    res.status(200).json({
+        success: true,
+        message: "Logged out successfully"
+    });
+};

--- a/backend/src/controllers/profile.controller.js
+++ b/backend/src/controllers/profile.controller.js
@@ -1,0 +1,49 @@
+import { User } from "../models/user.model.js";
+import { AppError } from "../utils/AppErrors.js";
+
+export const getProfile = async (req, res) => {
+  try {
+    const profile = await User.findProfileById(req.user.userId);
+
+    if (!profile) {
+      throw new AppError("USER_NOT_FOUND", 404);
+    }
+
+    res.status(200).json(profile);
+  } catch (error) {
+    console.error("Profile Error --> : ", error.message);
+    res.status(error.statusCode || 500).json({
+      success: false,
+      message: error.message || "Internal Server Error",
+    });
+  }
+};
+
+export const deleteProfile = async (req, res) => {
+  try {
+    const profile = await User.findById(req.user.userId);
+
+    if (!profile) {
+      throw new AppError("USER_NOT_FOUND", 404);
+    }
+
+    await User.deleteById(req.user.userId);
+
+    res.clearCookie("token", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: "lax"
+    });
+
+    res.status(200).json({
+      success: true,
+      message: "Account deleted successfully",
+    });
+  } catch (error) {
+    console.error("Delete Profile Error --> : ", error.message);
+    res.status(error.statusCode || 500).json({
+      success: false,
+      message: error.message || "Internal Server Error",
+    });
+  }
+};

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -40,6 +40,22 @@ export const User = {
       [id]
     );
     return rows[0] || null;
+  },
+
+  findProfileById: async (id) => {
+    const rows = await query(
+      "SELECT id, username, email, created_at, updated_at FROM users WHERE id = ?",
+      [id]
+    );
+
+    return rows[0] || null;
+  },
+
+  deleteById: async (id) => {
+    await query(
+      "DELETE FROM users WHERE id = ?",
+      [id]
+    );
   }
 
 }

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,11 +1,14 @@
 import express from "express";
 import {authSignupSchema, authLoginSchema} from "../schemas/auth.schema.js";
-import {signup, login} from "../controllers/auth.controller.js";
+import {signup, login, me, logout} from "../controllers/auth.controller.js";
 import {validateRequest} from "../middlewares/validate.middleware.js";
+import {authMiddleware} from "../middlewares/auth.middleware.js";
 
 const router = express.Router();
 
 router.post("/signup", validateRequest(authSignupSchema), signup);
 router.post("/login", validateRequest(authLoginSchema), login);
+router.get("/me", authMiddleware, me);
+router.post("/logout", authMiddleware, logout);
 
-export default router; 
+export default router;

--- a/backend/src/routes/profile.routes.js
+++ b/backend/src/routes/profile.routes.js
@@ -1,13 +1,12 @@
 import express from "express";
 import {authMiddleware} from "../middlewares/auth.middleware.js";
-
+import { getProfile, deleteProfile } from "../controllers/profile.controller.js";
 
 const router = express.Router();
 
-//router.use(authMiddleware);
+router.use(authMiddleware);
 
-router.get("/profile", (req, res) => {
-    res.send("User profile data 😶‍🌫️");
-})
+router.get("/profile", getProfile);
+router.delete("/profile", deleteProfile);
 
 export default router;

--- a/backend/src/services/auth/auth.service.js
+++ b/backend/src/services/auth/auth.service.js
@@ -39,8 +39,6 @@ export const loginService = async (userData) => {
 
     const {email, password} = userData;
 
-    // const user = await User.findOne({email}).select("+password");
-
     const user = await User.findByEmail(email);
     
     if(!user){
@@ -49,7 +47,7 @@ export const loginService = async (userData) => {
 
     const isPasswordValid = await bcrypt.compare(password, user.password_hash);
     if(!isPasswordValid){
-        throw new Error("INVALID_CREDENTIALS", 401);
+        throw new AppError("INVALID_CREDENTIALS", 401);
     }
 
     const token = jwt.sign(
@@ -66,3 +64,13 @@ export const loginService = async (userData) => {
         token,
     };
 }
+
+export const getSessionUserService = async (userId) => {
+    const user = await User.findById(userId);
+
+    if (!user) {
+        throw new AppError("USER_NOT_FOUND", 404);
+    }
+
+    return user;
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,7 @@ import EditIntegrationForm from './components/aiIntegrations/EditIntegrationForm
 // Test Route
 // import Test from './pages/Test'
 import ExecutionMain from './components/executions/ExecutionMain';
+import Profile from './pages/profile/Profile';
 
 function App() {
 
@@ -69,6 +70,7 @@ function App() {
                 </Route>
 
                 <Route path="/executions" element={<ExecutionMain />} />
+                <Route path="/profile" element={<Profile />} />
 
                 {/* <Route path="/test" element={<Test />} /> */}
 

--- a/frontend/src/api/auth.api.js
+++ b/frontend/src/api/auth.api.js
@@ -7,3 +7,11 @@ export const loginApi = (data) => {
 export const signupApi = (data) => {
     return api.post('/auth/signup', data);
 }
+
+export const meApi = () => {
+    return api.get('/auth/me');
+}
+
+export const logoutApi = () => {
+    return api.post('/auth/logout');
+}

--- a/frontend/src/api/profile.api.js
+++ b/frontend/src/api/profile.api.js
@@ -1,0 +1,5 @@
+import api from '../utils/axiox';
+
+export const getProfileApi = () => api.get('/user/profile');
+
+export const deleteProfileApi = () => api.delete('/user/profile');

--- a/frontend/src/components/common/SideBar.jsx
+++ b/frontend/src/components/common/SideBar.jsx
@@ -1,12 +1,13 @@
-import { NavLink } from 'react-router-dom'
+import { NavLink, useNavigate } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faHouse, faMicrochip, faCodeMerge, faCirclePlay, faBook, faCircleNodes, faRobot, faClock, faGear } from '@fortawesome/free-solid-svg-icons'
+import { faHouse, faMicrochip, faCodeMerge, faClock, faGear } from '@fortawesome/free-solid-svg-icons'
 import { FaRegUser } from "react-icons/fa";
 import { LuLogIn, LuLogOut} from "react-icons/lu";
 import useAuthStore from '@/stores/authStore'
 import Logo from "@/assets/logo.png"
 import useWorkflowData from '@/stores/workflowDataStore';
-
+import { logoutApi } from '@/api/auth.api';
+import { toast } from 'react-hot-toast';
 
 const Sidebar = () => {
 
@@ -14,10 +15,18 @@ const Sidebar = () => {
   const isAuthenticated  = useAuthStore( (state) => state.isAuthenticated ) || false;
   const logout = useAuthStore( (state) => state.logout );
   const clearData = useWorkflowData( (state) => state.clearData );
+  const navigate = useNavigate();
 
-  const handleLogout = () => {
-    logout();
-    clearData();
+  const handleLogout = async () => {
+    try {
+      await logoutApi();
+    } catch (error) {
+      toast.error(error || 'Logout failed');
+    } finally {
+      logout();
+      clearData();
+      navigate('/auth/login');
+    }
   };
 
 
@@ -28,9 +37,6 @@ const Sidebar = () => {
     {name: "Workflow", to: "/workflow", icon: faMicrochip},
     {name: "AI-Integrations", to: "/ai/integrations", icon: faCodeMerge}, 
     {name: "Executions", to: "/executions", icon: faClock},
-    // {name: "Logs", to: "/logs", icon: faBook},
-    // {name: "Webhooks", to: "/webhooks", icon: faCircleNodes},
-    // {name: "test", to: "/test", icon: faRobot},
   ]
 
   return (
@@ -87,7 +93,7 @@ const Sidebar = () => {
             ` ${basicStyle} ${isActive ? " text-white bg-zinc-800 shadow-lg ":  "text-zinc-400 hover:bg-zinc-900 hover:text-white" }
             `}
           >
-            <div className='w-8 h-8 rounded-full border border-emerald-50 flex items-center justify-center font-bold mr-2'>{/* {username[0]} */} <FaRegUser /></div>
+            <div className='w-8 h-8 rounded-full border border-emerald-50 flex items-center justify-center font-bold mr-2'><FaRegUser /></div>
             <span className="font-medium text-white">{username}</span>
 
           </NavLink>          

--- a/frontend/src/pages/profile/Profile.css
+++ b/frontend/src/pages/profile/Profile.css
@@ -1,0 +1,7 @@
+.profile-page {
+  min-height: calc(100vh - 120px);
+}
+
+.profile-card {
+  backdrop-filter: blur(10px);
+}

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -1,0 +1,122 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+import { deleteProfileApi, getProfileApi } from "@/api/profile.api";
+import { logoutApi } from "@/api/auth.api";
+import useAuthStore from "@/stores/authStore";
+import useWorkflowData from "@/stores/workflowDataStore";
+import "./Profile.css";
+
+const Profile = () => {
+  const navigate = useNavigate();
+  const logoutStore = useAuthStore((state) => state.logout);
+  const clearData = useWorkflowData((state) => state.clearData);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["profile"],
+    queryFn: async () => {
+      const response = await getProfileApi();
+      return response.data;
+    },
+  });
+
+  const logoutMutation = useMutation({
+    mutationFn: logoutApi,
+    onSuccess: () => {
+      logoutStore();
+      clearData();
+      navigate("/auth/login");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteProfileApi,
+    onSuccess: () => {
+      logoutStore();
+      clearData();
+      toast.success("Account deleted successfully");
+      navigate("/auth/signup");
+    },
+    onError: (error) => {
+      toast.error(error || "Failed to delete account");
+    },
+  });
+
+  const handleLogout = () => {
+    logoutMutation.mutate();
+  };
+
+  const handleDeleteAccount = () => {
+    const shouldDelete = window.confirm(
+      "Are you sure you want to delete your account? This action cannot be undone."
+    );
+
+    if (!shouldDelete) {
+      return;
+    }
+
+    deleteMutation.mutate();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="h-full w-full flex items-center justify-center text-xl text-zinc-300">
+        Loading profile...
+      </div>
+    );
+  }
+
+  return (
+    <section className="profile-page mx-auto w-full max-w-5xl p-6 md:p-8 text-white">
+      <div className="profile-card rounded-3xl border border-zinc-700 bg-zinc-950/80 p-6 md:p-8 shadow-2xl">
+        <h1 className="text-3xl md:text-4xl font-bold mb-2">My Profile</h1>
+        <p className="text-zinc-400 mb-8">Manage your account details and security settings.</p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+          <InfoBlock label="User ID" value={data?.id} />
+          <InfoBlock label="Username" value={data?.username} />
+          <InfoBlock label="Email" value={data?.email} />
+          <InfoBlock
+            label="Joined"
+            value={data?.created_at ? new Date(data.created_at).toLocaleString() : "-"}
+          />
+          <InfoBlock
+            label="Last Updated"
+            value={data?.updated_at ? new Date(data.updated_at).toLocaleString() : "-"}
+          />
+        </div>
+
+        <div className="mt-10 flex flex-col sm:flex-row gap-3">
+          <button
+            type="button"
+            onClick={handleLogout}
+            disabled={logoutMutation.isPending || deleteMutation.isPending}
+            className="rounded-xl border border-zinc-600 px-5 py-3 font-semibold text-zinc-200 hover:bg-zinc-900 transition-colors disabled:opacity-50"
+          >
+            {logoutMutation.isPending ? "Logging out..." : "Logout"}
+          </button>
+
+          <button
+            type="button"
+            onClick={handleDeleteAccount}
+            disabled={logoutMutation.isPending || deleteMutation.isPending}
+            className="rounded-xl bg-red-600 px-5 py-3 font-semibold text-white hover:bg-red-500 transition-colors disabled:opacity-50"
+          >
+            {deleteMutation.isPending ? "Deleting account..." : "Delete Account"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const InfoBlock = ({ label, value }) => {
+  return (
+    <div className="rounded-xl border border-zinc-700 bg-zinc-900/80 p-4">
+      <p className="text-zinc-400 text-sm">{label}</p>
+      <p className="text-lg font-semibold break-words">{value || "-"}</p>
+    </div>
+  );
+};
+
+export default Profile;

--- a/frontend/src/utils/ProtectedRoute.jsx
+++ b/frontend/src/utils/ProtectedRoute.jsx
@@ -1,12 +1,37 @@
-import useAuthStore from "../stores/authStore";
+import { useEffect, useState } from "react";
 import { Navigate, useLocation } from "react-router-dom";
+import useAuthStore from "../stores/authStore";
+import { meApi } from "../api/auth.api";
 
-export const ProtectedRoute = ( {children} ) => {
-    const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-    const hasHydrated = useAuthStore((state) => state.hasHydrated);
-    const location = useLocation();
+export const ProtectedRoute = ({ children }) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
+  const setAuth = useAuthStore((state) => state.setAuth);
+  const logout = useAuthStore((state) => state.logout);
 
-       if (!hasHydrated) {
+  const location = useLocation();
+  const [isCheckingSession, setIsCheckingSession] = useState(true);
+
+  useEffect(() => {
+    const verifySession = async () => {
+      if (!hasHydrated) {
+        return;
+      }
+
+      try {
+        const response = await meApi();
+        setAuth(response.data);
+      } catch (error) {
+        logout();
+      } finally {
+        setIsCheckingSession(false);
+      }
+    };
+
+    verifySession();
+  }, [hasHydrated, setAuth, logout]);
+
+  if (!hasHydrated || isCheckingSession) {
     return (
       <div className="flex justify-center items-center text-3xl h-screen">
         Loading...
@@ -15,14 +40,8 @@ export const ProtectedRoute = ( {children} ) => {
   }
 
   if (!isAuthenticated) {
-    return (
-      <Navigate 
-        to="/auth/login" 
-        replace 
-        state={{ from: location }}
-      />
-    );
+    return <Navigate to="/auth/login" replace state={{ from: location }} />;
   }
-    
-    return children;
-}
+
+  return children;
+};


### PR DESCRIPTION
### Motivation
- Make server-side session (httpOnly cookie + JWT verification) the source of truth instead of trusting persisted client Zustand state alone.  
- Provide a user profile UI and API to view and delete accounts.  
- Synchronize client logout with the backend to avoid stale client state/cookies.

### Description
- Added session endpoints and handlers: `GET /api/auth/me` and `POST /api/auth/logout` in `backend/src/routes/auth.routes.js` and `backend/src/controllers/auth.controller.js` to validate cookie-backed sessions and clear cookies.  
- Implemented profile APIs under `/api/user/profile` with `GET` (profile fetch) and `DELETE` (account deletion + cookie clear) in `backend/src/routes/profile.routes.js` and `backend/src/controllers/profile.controller.js`.  
- Extended `User` model with `findProfileById` and `deleteById` helpers in `backend/src/models/user.model.js` and added `getSessionUserService` to `backend/src/services/auth/auth.service.js`.  
- Updated frontend to verify sessions server-side by changing `ProtectedRoute` to call backend `me` (`frontend/src/utils/ProtectedRoute.jsx`), added `me`/`logout` API calls (`frontend/src/api/auth.api.js`), and wired a new `/profile` route with a Profile page component and styling (`frontend/src/pages/profile/Profile.jsx`, `Profile.css`) plus `frontend/src/api/profile.api.js`.  
- Updated sidebar logout flow to call backend `logout` before clearing Zustand and navigating (`frontend/src/components/common/SideBar.jsx`).

### Testing
- Ran frontend build with `npm run build` in `frontend/` and it completed successfully.  
- Performed static checks with `node --check` on updated backend files and they passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5376226d0832785394fa37766ccae)