### PR TITLE
Add dedicated Webhook trigger UI and validate webhook execution

### DIFF
--- a/backend/src/schemas/workflow.schema.js
+++ b/backend/src/schemas/workflow.schema.js
@@ -76,6 +76,16 @@ const HttpConfig = z.object({
     }
 });
 
+
+const HttpWebhookConfig = z.object({
+    method: z.enum(["ANY", "GET", "POST", "PUT", "PATCH", "DELETE"]),
+    variable: z.string().min(2, "Variable name is too small.").regex(
+        /^[a-zA-Z0-9-_]+$/,
+        "Special characters are not allowed. Please use only letters, numbers, hypen: (-) and underscore: (_)."
+    ),
+    url: z.string(),
+});
+
 const AI = z.object({
     variable: z.string().min(2, "Variable name is too small.").max(15, "Variable name is too big").regex( 
         /^[a-zA-Z0-9-_]+$/, 
@@ -123,6 +133,20 @@ const workflowNodeSchema = BaseNodeSchema.superRefine((node, ctx) => {
                     message: issue.message,
                     path: ["data", "config", ...issue.path],
                 })
+            });
+        }
+    }
+
+
+    if (node.data.triggerType === "httpWebhook") {
+        const result = HttpWebhookConfig.safeParse(node.data.config);
+        if (!result.success) {
+            result.error.issues.forEach(issue => {
+                ctx.addIssue({
+                    code: issue.code,
+                    message: issue.message,
+                    path: ["data", "config", ...issue.path],
+                });
             });
         }
     }

--- a/backend/src/services/workflow/nodeExecutor/executorRegistry.js
+++ b/backend/src/services/workflow/nodeExecutor/executorRegistry.js
@@ -1,6 +1,7 @@
 import { AppError } from "../../../utils/AppErrors.js";
 import { manualExecutor } from "./manualExecutor.js";
 import { httpExecutor } from "./http/httpExecutor.js";
+import { httpWebhookExecutor } from "./http/httpWebhookExecutor.js";
 import { geminiAIExecutor } from "./geminiAIExecutor.js";
 import { perplexityAIExecutor } from "./perplexityAIExecutor.js";
 import { openAIExecutor } from "./openAIExecutor.js";
@@ -12,6 +13,7 @@ import { handleGoogleForm } from "./googleForm/getResponse.js";
 export const executorRegistry =  {
     manual: manualExecutor,
     http: httpExecutor,
+    httpWebhook: httpWebhookExecutor,
     geminiAI: geminiAIExecutor,
     perplexityAI: perplexityAIExecutor,
     openAI: openAIExecutor,

--- a/backend/src/services/workflow/nodeExecutor/http/httpWebhookExecutor.js
+++ b/backend/src/services/workflow/nodeExecutor/http/httpWebhookExecutor.js
@@ -2,43 +2,75 @@ import { NonRetriableError } from "inngest";
 import { httpRequestChannel } from "../../../../inngest/workflowStatus.js";
 import { createExecutionResult } from "../../../../utils/executionResult.js";
 
-export const httpWebhookExecutor = async ({data, nodeId, context, publish}) => {
+const ALLOWED_METHODS = ["ANY", "GET", "POST", "PUT", "PATCH", "DELETE"];
+
+export const httpWebhookExecutor = async ({ data, nodeId, context, publish }) => {
+  await publish(
+    httpRequestChannel().status({
+      nodeId,
+      status: "loading",
+    }),
+  );
+
+  const config = data?.config || {};
+  const method = String(config?.method || "").toUpperCase();
+
+  if (!data?.isConfigured || !config?.variable || !config?.url || !ALLOWED_METHODS.includes(method)) {
     await publish(
-        httpRequestChannel().status({
-            nodeId,
-            status: "loading",
-        })
+      httpRequestChannel().status({
+        nodeId,
+        status: "error",
+      }),
     );
+    throw new NonRetriableError("Webhook node is not configured correctly.");
+  }
 
-    if (!data.isConfigured || !["GET", "POST", "PUT", "PATCH", "DELETE"].includes(data?.config?.method) || !data.config.variable ) {
-        await publish(
-            httpRequestChannel().status({
-                nodeId,
-                status: "error",
-            })
-        );
-        throw new NonRetriableError("Node is not configured.")
-    }
+  const requestPayload = context?.httpWebhook;
 
-    if (["POST", "PUT", "PATCH"].includes(method) && !data.config.body && !data.config.headers) {
-        await publish(
-            httpRequestChannel().status({
-                nodeId,
-                status: "error",
-            })
-        );
-        throw new NonRetriableError("Node is not configured.");
-    }
+  if (!requestPayload || typeof requestPayload !== "object") {
+    await publish(
+      httpRequestChannel().status({
+        nodeId,
+        status: "error",
+      }),
+    );
+    throw new NonRetriableError("No webhook request payload found in execution context.");
+  }
 
-    const startTime = Date.now();
+  const incomingMethod = String(requestPayload?.method || "").toUpperCase();
 
-    return createExecutionResult({
-        output:{
-            nodeId,
-            triggered: true,
-            startTime: startTime,
-            endTime: Date.now(), 
-            data: context?.payload || {},
-        },
-    });
-}
+  if (!incomingMethod || (method !== "ANY" && incomingMethod !== method)) {
+    await publish(
+      httpRequestChannel().status({
+        nodeId,
+        status: "error",
+      }),
+    );
+    throw new NonRetriableError(`Webhook method mismatch. Expected ${method}, received ${incomingMethod || "UNKNOWN"}.`);
+  }
+
+  const startTime = Date.now();
+
+  await publish(
+    httpRequestChannel().status({
+      nodeId,
+      status: "success",
+    }),
+  );
+
+  return createExecutionResult({
+    output: {
+      nodeId,
+      triggered: true,
+      startTime,
+      endTime: Date.now(),
+      data: {
+        method: incomingMethod,
+        headers: requestPayload?.headers || {},
+        query: requestPayload?.query || {},
+        body: requestPayload?.body || {},
+      },
+      status: true,
+    },
+  });
+};

--- a/frontend/src/components/workflow/editor/WorkflowSidebar.jsx
+++ b/frontend/src/components/workflow/editor/WorkflowSidebar.jsx
@@ -1,4 +1,4 @@
-import {MousePointer, Globe,X} from "lucide-react"
+import { MousePointer, Globe, Webhook } from "lucide-react"
 import useEditorUIStore from "@/stores/workflowEditorStore";
 import CloseBtn from "@/components/common/CloseBtn";
 //import toast from "react-hot-toast";
@@ -53,20 +53,33 @@ const WorkflowSidebar = ({ onClose, setTriggerType }) => {
             </div>
         </div>
 
-        {/* HTTP Request */}
-
-        <div className="flex items-center  gap-4 mt-5 px-5 py-2 border border-zinc-600 rounded-xl hover:border-zinc-500
-         hover:bg-zinc-800 cursor-pointer"
-         onClick={()=> {
-          handleOnClick("HTTP Request", `${triggerType === "trigger" ? "httpWebhook" : "http"}`);
-         }}
-         >
+        {triggerType === "trigger" ? (
+          <div
+            className="flex items-center gap-4 mt-5 px-5 py-2 border border-zinc-600 rounded-xl hover:border-zinc-500 hover:bg-zinc-800 cursor-pointer"
+            onClick={() => {
+              handleOnClick("Webhook", "httpWebhook");
+            }}
+          >
+            <Webhook size={28} className="text-violet-400" />
+            <div>
+              <h2 className="text-xl">Webhook</h2>
+              <p className="text-zinc-400 text-sm ">Trigger this flow from any external HTTP request.</p>
+            </div>
+          </div>
+        ) : (
+          <div
+            className="flex items-center gap-4 mt-5 px-5 py-2 border border-zinc-600 rounded-xl hover:border-zinc-500 hover:bg-zinc-800 cursor-pointer"
+            onClick={() => {
+              handleOnClick("HTTP Request", "http");
+            }}
+          >
             <Globe size={28} className="text-blue-600" />
             <div>
-                <h2 className="text-xl">HTTP Request</h2>
-                <p className="text-zinc-400 text-sm ">Send data to or fetch data from an API.</p>
+              <h2 className="text-xl">HTTP Request</h2>
+              <p className="text-zinc-400 text-sm ">Send data to or fetch data from an API.</p>
             </div>
-        </div>
+          </div>
+        )}
 
          {/* Google Form */}
         <div className="flex items-center  gap-4 mt-5 px-5 py-2 border border-zinc-600 rounded-xl hover:border-zinc-500

--- a/frontend/src/components/workflow/editor/config-panels/http/HTTPConfig.jsx
+++ b/frontend/src/components/workflow/editor/config-panels/http/HTTPConfig.jsx
@@ -1,21 +1,19 @@
 import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import { Globe, MoveLeft } from "lucide-react";
+import { Globe } from "lucide-react";
 import CloseBtn from "@/components/common/CloseBtn";
 import useEditorUIStore from "@/stores/workflowEditorStore";
-import useWorkflowData from '@/stores/workflowDataStore';
 import toast from 'react-hot-toast';
 
 const HTTPConfig = ({ selectedNode, nodeType, onClose, setNodeConfig }) => {
 
   const {setIsConfigSidebarClose} = useEditorUIStore();
-  const {workflowId} = useWorkflowData();
 
   const { register, handleSubmit, setValue, control, formState: { errors }, setError } = useForm({
       defaultValues: {
         method: selectedNode?.data?.config?.method || 'GET',
-        variable: selectedNode?.data?.config?.variable || null,
-        url: selectedNode?.data?.config?.url || `https://linus-terrible-murray.ngrok-free.dev/api/webhook/${workflowId}/http-webhook`,
+        variable: selectedNode?.data?.config?.variable || '',
+        url: selectedNode?.data?.config?.url || '',
         headers: JSON.stringify(selectedNode?.data?.config?.headers) || {
   "Content-Type": "application/json"
 },
@@ -38,7 +36,6 @@ const HTTPConfig = ({ selectedNode, nodeType, onClose, setNodeConfig }) => {
   const isDeleteMethod = method === 'DELETE'
 
   const onSubmit = async (data) => {
-    console.log(data.variable)
     try {
 
       if(["POST", "PUT", "PATCH"].includes(data.method) && (!data.body || !data.headers)){

--- a/frontend/src/components/workflow/editor/config-panels/http/WebhookConfig.jsx
+++ b/frontend/src/components/workflow/editor/config-panels/http/WebhookConfig.jsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo } from "react";
+import { Globe, Webhook } from "lucide-react";
+import CloseBtn from "@/components/common/CloseBtn";
+import CopyToClipboard from "@/components/common/CopyToClipboard";
+import useEditorUIStore from "@/stores/workflowEditorStore";
+import useWorkflowData from "@/stores/workflowDataStore";
+
+const WebhookConfig = ({ selectedNode, onClose, setNodeConfig }) => {
+  const { setIsConfigSidebarClose } = useEditorUIStore();
+  const { workflowId } = useWorkflowData();
+
+  const systemVariable = useMemo(() => {
+    const nodeSuffix = String(selectedNode?.id || "").replace(/[^a-zA-Z0-9_]/g, "").slice(0, 8);
+    return `webhook_${nodeSuffix || "payload"}`;
+  }, [selectedNode?.id]);
+
+  const webhookUrl = useMemo(() => {
+    if (!workflowId) return "";
+    return `${window.location.origin}/api/webhook/${workflowId}/http-webhook`;
+  }, [workflowId]);
+
+  useEffect(() => {
+    if (!selectedNode?.id || !workflowId) return;
+
+    const existingConfig = selectedNode?.data?.config || {};
+
+    if (
+      existingConfig?.method === "ANY" &&
+      existingConfig?.variable === systemVariable &&
+      existingConfig?.url === webhookUrl
+    ) {
+      return;
+    }
+
+    setNodeConfig({
+      method: "ANY",
+      variable: systemVariable,
+      url: webhookUrl,
+    });
+  }, [selectedNode?.id, selectedNode?.data?.config, setNodeConfig, systemVariable, webhookUrl, workflowId]);
+
+  return (
+    <aside className="absolute top-0 right-0 h-full w-1/3 m-1 bg-black border border-zinc-700 rounded-lg text-white z-50 flex flex-col">
+      <div className="flex px-4 py-3 border-b-2 border-zinc-700 relative">
+        <div>
+          <h2 className="text-3xl font-semibold text-zinc-100 font-mono flex items-center gap-3">
+            <span className="p-2 border border-zinc-400 rounded-xl">
+              <Webhook size={20} />
+            </span>
+            Webhook
+          </h2>
+          <p className="text-sm text-[#E5E5E5] mt-2 font-normal">
+            This webhook is fully system-generated. Copy the details and send requests to trigger this workflow.
+          </p>
+        </div>
+        <CloseBtn onClose={onClose} />
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6">
+        <section>
+          <h3 className="text-sm font-semibold text-zinc-200 mb-3">Variable (System-defined)</h3>
+          <div className="w-full rounded-md bg-zinc-900 border border-zinc-700 px-3 py-2 text-sm text-white flex items-center justify-between gap-3">
+            <span className="truncate">{`{{${systemVariable}.output.data}}`}</span>
+            <CopyToClipboard text={`{{${systemVariable}.output.data}}`} />
+          </div>
+          <p className="text-[12px] mt-1 text-zinc-400">
+            Use this variable in next nodes to access webhook payload data.
+          </p>
+        </section>
+
+        <section>
+          <h3 className="text-sm font-semibold text-zinc-200 mb-3">Webhook URL (System-defined)</h3>
+          <div className="w-full rounded-md bg-zinc-900 border border-zinc-700 px-3 py-2 text-sm text-white flex items-center justify-between gap-3">
+            <span className="truncate">{webhookUrl || "Generating webhook URL..."}</span>
+            <CopyToClipboard text={webhookUrl} />
+          </div>
+          <p className="text-[12px] mt-1 text-zinc-400">Send requests to this URL to trigger workflow execution.</p>
+        </section>
+
+        <section>
+          <h3 className="text-sm font-semibold text-zinc-200 mb-2">Method</h3>
+          <div className="w-24 rounded-md bg-zinc-900 border border-zinc-700 px-3 py-2 text-sm text-white text-center">ANY</div>
+        </section>
+
+        <section className="rounded-lg border border-zinc-700 bg-zinc-900/40 p-3">
+          <h4 className="text-sm font-semibold flex items-center gap-2"><Globe size={14} /> How to use</h4>
+          <p className="text-xs text-zinc-300 mt-2 leading-relaxed">
+            1) Copy the webhook URL above. 2) From your app/server/client, send an HTTP request with any method (GET/POST/PUT/PATCH/DELETE) to this URL. 3) The incoming request details are available in downstream nodes via the variable shown above.
+          </p>
+        </section>
+      </div>
+
+      <div className="border-t border-zinc-600 px-4 py-3 bg-zinc-900/50">
+        <button
+          type="button"
+          onClick={setIsConfigSidebarClose}
+          className="w-full flex items-center justify-center gap-2 bg-white text-black font-bold py-3 rounded-xl hover:bg-zinc-200 transition-colors"
+        >
+          Done
+        </button>
+      </div>
+    </aside>
+  );
+};
+
+export default WebhookConfig;

--- a/frontend/src/components/workflow/editor/sidebar/ConfigSidebar.jsx
+++ b/frontend/src/components/workflow/editor/sidebar/ConfigSidebar.jsx
@@ -2,6 +2,7 @@ import useEditorUIStore from "@/stores/workflowEditorStore";
 import DefaultConfig from "../config-panels/defaultConfig/DefaultConfig";
 import ManualTriggerConfig from "../config-panels/manualTrigger/ManualTriggerConfig";
 import HTTPConfig from "../config-panels/http/HTTPConfig";
+import WebhookConfig from "../config-panels/http/WebhookConfig";
 import GoogleFormConfig from "../config-panels/googleForm/GoogleFormConfig";
 import GeminiConfig from "../config-panels/ai/gemini/GeminiConfig";
 import PerplexityConfig from "../config-panels/ai/perplexity/PerplexityConfig";
@@ -30,7 +31,7 @@ const ConfigSidebar = ({ nodes, onClose, setNodeConfig }) => {
         return <HTTPConfig selectedNode={selectedNode} onClose={onClose} nodeType={nodeType} setNodeConfig={setNodeConfig} />;
 
     case "httpWebhook": 
-        return <HTTPConfig selectedNode={selectedNode} onClose={onClose} nodeType={nodeType} setNodeConfig={setNodeConfig} />;
+        return <WebhookConfig selectedNode={selectedNode} onClose={onClose} setNodeConfig={setNodeConfig} />;
         
     case "geminiAI":
       return <GeminiConfig selectedNode={selectedNode} onClose={onClose} setNodeConfig={setNodeConfig} />;

--- a/frontend/src/components/workflow/hooks/useWorkflow.js
+++ b/frontend/src/components/workflow/hooks/useWorkflow.js
@@ -173,6 +173,7 @@ export const useWorkflow = () => {
                 }
                 
                 const configHandler = nodeConfigMap[triggerType];
+                const initialConfig = { ...(configHandler?.defaultConfig || {}) };
 
                 updatedNodes = nds.map((node) =>
                     node.id === activeNodeId
@@ -181,9 +182,10 @@ export const useWorkflow = () => {
                             data: {
                                 label,
                                 isTrigger: true,
-                                isConfigured: configHandler.isComplete(),
+                                isConfigured: configHandler.isComplete(initialConfig),
                                 triggerType,
-                                summary: configHandler.buildSummary(),
+                                config: initialConfig,
+                                summary: configHandler.buildSummary(initialConfig),
                             },
                         } : 
                     node

--- a/frontend/src/components/workflow/utils/mapTriggerName.js
+++ b/frontend/src/components/workflow/utils/mapTriggerName.js
@@ -1,6 +1,7 @@
 export const triggerNameMap = {
     'gmail': 'Gmail',
     'http': 'HTTP Request',
+    'httpWebhook': 'Webhook',
     'manual': 'Manual Trigger',
     'googleForm': 'Google Form',
     'googleDrive': 'Google Drive',

--- a/frontend/src/components/workflow/utils/nodeConfigMap.js
+++ b/frontend/src/components/workflow/utils/nodeConfigMap.js
@@ -38,29 +38,26 @@ export const nodeConfigMap = {
 
     httpWebhook: {
         defaultConfig: {
-            method: "GET",
+            method: "ANY",
             variable: "",
             url: "",
-            headers: "",
-            body: "",
         },
 
-        buildSummary: (config) =>
-        {
+        buildSummary: (config) => {
             try {
                 return config?.url
-                ? `${config.method} ${new URL(config.url).pathname}`
-                : "HTTP Request"
+                    ? `Webhook (${config.method || "ANY"}) ${new URL(config.url).pathname}`
+                    : "Webhook";
             } catch (error) {
                 console.log(error);
-                return "HTTP Request";
+                return "Webhook";
             }
-        }// TODOs : Fix this build summary for the url (When user enters only the variable name in the url field, it breaks the summary because of URL constructor. We need to handle that case.)
-        , 
+        },
 
         isComplete: (config) =>
-            Boolean(config?.url && config?.method),
+            Boolean(config?.url && config?.variable && config?.method),
     },
+
 
     googleForm: {
         defaultConfig: {},


### PR DESCRIPTION
### Motivation
- Separate webhook triggers from generic HTTP requests so trigger nodes show a dedicated, system-managed Webhook entry in the sidebar.
- Provide a system-defined config panel for webhooks so users only copy the generated variable and URL (no manual config required).
- Harden backend execution of webhook triggers by validating node config and incoming request payload/method before continuing workflow execution.

### Description
- Added a new `WebhookConfig` panel that auto-generates a system variable and webhook URL, displays them with copy buttons, shows `ANY` as the method, and includes usage instructions for sending requests (frontend: `frontend/src/components/workflow/editor/config-panels/http/WebhookConfig.jsx`).
- Updated the sidebar and config routing so triggers use a distinct "Webhook" item and `httpWebhook` opens the new `WebhookConfig` while action nodes keep `HTTP Request` (frontend: `WorkflowSidebar.jsx`, `ConfigSidebar.jsx`).
- Updated node defaults and summary handling so `httpWebhook` has webhook-specific defaults and is seeded into node state when selecting a trigger (frontend: `nodeConfigMap.js`, `useWorkflow.js`, `mapTriggerName.js`).
- Implemented `httpWebhookExecutor` with baseline checks (valid config, payload presence, method match with support for `ANY`) and normalized output for downstream nodes, and registered it in the executor registry (backend: `http/httpWebhookExecutor.js`, `executorRegistry.js`).
- Extended workflow schema to validate `httpWebhook` config (including `ANY` method) and removed prefilled webhook URL from the HTTP action config defaults to avoid confusion (backend: `workflow.schema.js`, frontend: `HTTPConfig.jsx`).

### Testing
- Run `npm run build` (frontend) and the build completed successfully.
- Run `npm run lint` (frontend) which reported failures unrelated to the changes (pre-existing unused vars and other lint issues in untouched files).
- `node --check backend/src/services/workflow/nodeExecutor/http/httpWebhookExecutor.js` passed syntax checks.
- `node --check backend/src/schemas/workflow.schema.js` passed syntax checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f3134018832797b4c54af03ec468)