### PR TITLE
Add required File Content field to Drive Create File and resolve variables at runtime

### DIFF
--- a/backend/src/services/workflow/nodeExecutor/googleDrive/actions/createFile.js
+++ b/backend/src/services/workflow/nodeExecutor/googleDrive/actions/createFile.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import FormData from "form-data";
 import { NonRetriableError } from "inngest";
+import Handlebars from "handlebars";
 import { Integration } from "../../../../../models/integration/integration.model.js";
 import { createExecutionResult } from "../../../../../utils/executionResult.js";
 
@@ -13,24 +14,37 @@ const getAccessToken = async (userId, accountId) => {
 };
 
 export const handleCreateFile = async ({ data, nodeId, context, userId }) => {
-  const { fileName, content, driveId } = data.config;       // there is no content 
+  const { fileName, content, driveId, folderId } = data.config;
 
-  if (!fileName || !driveId) {
+  if (!fileName?.trim() || !content?.trim() || !driveId) {
     throw new NonRetriableError("Missing required fields.");
+  }
+
+  const resolvedFileName = Handlebars.compile(fileName)(context);
+  const resolvedContent = Handlebars.compile(content)(context);
+
+  if (!resolvedFileName?.trim() || !resolvedContent?.trim()) {
+    throw new NonRetriableError("File name and content are required.");
   }
 
   const accessToken = await getAccessToken(userId, driveId);
 
+  const metadata = {
+    name: resolvedFileName,
+    mimeType: "text/plain",
+  };
+
+  if (folderId) {
+    metadata.parents = [folderId];
+  }
+
   const form = new FormData();
   form.append(
     "metadata",
-    JSON.stringify({
-      name: fileName,
-      mimeType: "text/plain",
-    }),
+    JSON.stringify(metadata),
     { contentType: "application/json" }
   );
-  form.append("file", content || "", { contentType: "text/plain" });
+  form.append("file", resolvedContent, { contentType: "text/plain" });
 
   const response = await axios.post(
     "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",

--- a/frontend/src/components/workflow/editor/config-panels/googleDrive/ConfigState.jsx
+++ b/frontend/src/components/workflow/editor/config-panels/googleDrive/ConfigState.jsx
@@ -47,6 +47,7 @@ const ConfigState = ({ data, handleConnect, selectedNode, setNodeConfig }) => {
       targetId: config.targetId || '',
       fileUrl: config.fileUrl || '',
       fileName: config.fileName || '',
+      content: config.content || '',
       folderName: config.folderName || '',
       fileUpload: null,
     },
@@ -70,6 +71,7 @@ const ConfigState = ({ data, handleConnect, selectedNode, setNodeConfig }) => {
       targetId: config.targetId || '',
       fileUrl: config.fileUrl || '',
       fileName: config.fileName || '',
+      content: config.content || '',
       folderName: config.folderName || '',
       fileUpload: null,
     });
@@ -144,6 +146,7 @@ const ConfigState = ({ data, handleConnect, selectedNode, setNodeConfig }) => {
       targetId: formData.targetId,
       fileUrl: formData.fileUrl,
       fileName: formData.fileName.trim(),
+      content: formData.content,
       folderName: formData.folderName.trim(),
       fileUpload: formData.fileUpload?.name || '',
     });
@@ -313,6 +316,23 @@ const ConfigState = ({ data, handleConnect, selectedNode, setNodeConfig }) => {
               className={inputClass}
             />
             {errors.fileName && <p className={errorClass}>{errors.fileName.message}</p>}
+
+            <label className="text-sm font-bold uppercase tracking-wider text-zinc-200">
+              File Content
+            </label>
+            <textarea
+              {...register('content', {
+                validate: (val) =>
+                  event !== 'create_file' || !!val?.trim() || 'File content is required',
+              })}
+              rows={6}
+              placeholder="Enter file content (supports variables like {{webhook.body.name}})"
+              className={inputClass}
+            />
+            <p className="text-[12px] text-zinc-400">
+              This content will be written inside the file in Google Drive.
+            </p>
+            {errors.content && <p className={errorClass}>{errors.content.message}</p>}
           </section>
         )}
 


### PR DESCRIPTION
### Motivation
- Enable creating Google Drive files with dynamic text content so workflows can write resolved variables into file bodies at execution time.

### Description
- Frontend: added a new required `content` form field (multi-line `textarea`) that is shown only when `event === 'create_file'`, includes the placeholder `Enter file content (supports variables like {{webhook.body.name}})`, helper text, and client-side validation returning `File content is required` when empty, and the value is persisted in form defaults/reset and saved via `setNodeConfig` as `content`.
- Frontend: preserved existing `fileName` behavior and validation for the `create_file` event and ensured both `fileName` and `content` are included in the saved node config payload.
- Backend: updated the `createFile` action to require `fileName`, `content`, and `driveId`, resolve templates in both `fileName` and `content` at runtime using `Handlebars`, and perform a multipart upload to Google Drive using resolved values; optional `folderId` is added to `metadata.parents` when present.
- Backend: the uploaded file metadata now uses the resolved file name and the file body uses the resolved content when calling the Drive upload API.

### Testing
- Ran `node --check backend/src/services/workflow/nodeExecutor/googleDrive/actions/createFile.js` which passed and indicates the backend file is syntactically valid.
- Ran `npm run lint` for the frontend which failed due to pre-existing unrelated lint issues in other files (unused imports/vars and a hook dependency warning) and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61982021c832787b744da10e772c9)