### PR TITLE
Add landing navbar navigation and static info pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,10 @@ import AppLayout from "./layouts/AppLayout";
 
 // Landing
 import Landing from './pages/landing/Landing'
+import Features from './pages/landing/Features'
+import Integrations from './pages/landing/Integrations'
+import Developer from './pages/landing/Developer'
+import About from './pages/landing/About'
 import Home from "./components/home/Main";
 
 // Auth Routes
@@ -41,6 +45,10 @@ function App() {
         <Routes>
 
           <Route path="/" element={<Landing />} />
+          <Route path="/features" element={<Features />} />
+          <Route path="/integrations" element={<Integrations />} />
+          <Route path="/developer" element={<Developer />} />
+          <Route path="/about" element={<About />} />
 
           <Route path='/auth/login' element={
             <GuestRoute>

--- a/frontend/src/components/landing/HeroSection.jsx
+++ b/frontend/src/components/landing/HeroSection.jsx
@@ -17,7 +17,7 @@ const HeroSection = () => {
                     Experience cutting-edge solutions designed to elevate productivity and
                     deliver results like never before.
                 </p>
-                <button className='hero-action-btn'><Button text="Get Started" to="/auth/login" /></button>
+                <div className='hero-action-btn'><Button text="Get Started" to="/auth/login" /></div>
             </div>
 
             <div className="hero-image">

--- a/frontend/src/components/landing/Navbar.jsx
+++ b/frontend/src/components/landing/Navbar.jsx
@@ -1,31 +1,29 @@
 import './Navbar.css'
-import {Link} from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import Logo from '@/assets/logo.png'
 import Button from '@/components/common/Button'
 
 const Navbar = () => {
   return (
-    <>
-        <div className="navbar text-white flex items-center justify-between">
-            <div className='nav-left flex items-center justify-between gap-1'>
-                <div className="navbar-logo">
-                    <img src={Logo} alt="FlowAI Logo" width={80}/>
-                </div>
-            </div>
-            <div className="nav-center ">
-                <ul className=' nav-elements flex items-center justify-between gap-[40px] '>
-                    <li><Link to="#" className='nav-link' onClick={(e) => e.preventDefault()}>Home</Link></li>
-                    <li><Link to="#" className='nav-link' onClick={(e) => e.preventDefault()}>Features</Link></li>
-                    <li><Link to="#" className='nav-link' onClick={(e) => e.preventDefault()}>Integrations</Link></li>
-                    <li><Link to="#" className='nav-link' onClick={(e) => e.preventDefault()}>Developers</Link></li>
-                    <li><Link to="#" className='nav-link' onClick={(e) => e.preventDefault()}>About</Link></li>
-                </ul>
-            </div>
-            <div className="nav-right">
-                <button className='get-started-btn '><Button text="Get Started" to="/auth/login" /> </button>
-            </div>
+    <div className="navbar text-white flex items-center justify-between">
+      <div className="nav-left flex items-center justify-between gap-1">
+        <div className="navbar-logo">
+          <img src={Logo} alt="FlowAI Logo" width={80} />
         </div>
-    </>
+      </div>
+      <div className="nav-center ">
+        <ul className=" nav-elements flex items-center justify-between gap-[40px] ">
+          <li><Link to="/" className="nav-link">Home</Link></li>
+          <li><Link to="/features" className="nav-link">Features</Link></li>
+          <li><Link to="/integrations" className="nav-link">Integrations</Link></li>
+          <li><Link to="/developer" className="nav-link">Developer</Link></li>
+          <li><Link to="/about" className="nav-link">About</Link></li>
+        </ul>
+      </div>
+      <div className="nav-right">
+        <Button text="Get Started" to="/auth/login" />
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/pages/landing/About.jsx
+++ b/frontend/src/pages/landing/About.jsx
@@ -1,0 +1,31 @@
+import Navbar from '@/components/landing/Navbar'
+import StarPattern from '@/components/common/StarPattern'
+import './LandingInfo.css'
+
+const About = () => {
+  return (
+    <div className="info-page">
+      <StarPattern />
+      <div className="stars1"></div>
+      <div className="stars2"></div>
+      <div className="stars3"></div>
+      <Navbar />
+
+      <section className="info-content">
+        <h1 className="info-title">About FlowAI</h1>
+        <p className="info-subtitle">
+          FlowAI is a workflow automation project that combines AI and productivity integrations to help users build
+          intelligent, event-driven workflows from a single platform.
+        </p>
+        <ul className="info-list">
+          <li>Design custom automations with a visual workflow editor.</li>
+          <li>Connect AI providers and productivity tools in one place.</li>
+          <li>Use trigger-action logic to automate repetitive tasks.</li>
+          <li>Scale routine operations with reliable, reusable workflow pipelines.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}
+
+export default About

--- a/frontend/src/pages/landing/Developer.jsx
+++ b/frontend/src/pages/landing/Developer.jsx
@@ -1,0 +1,35 @@
+import Navbar from '@/components/landing/Navbar'
+import StarPattern from '@/components/common/StarPattern'
+import './LandingInfo.css'
+
+const Developer = () => {
+  return (
+    <div className="info-page">
+      <StarPattern />
+      <div className="stars1"></div>
+      <div className="stars2"></div>
+      <div className="stars3"></div>
+      <Navbar />
+
+      <section className="info-content">
+        <h1 className="info-title">Developer</h1>
+        <p className="info-subtitle">
+          This project is developed by <strong>Anurag</strong>.
+        </p>
+        <p className="info-subtitle">
+          GitHub Project Link:{' '}
+          <a
+            className="info-link"
+            href="https://github.com/Anurag/ai-power-workflow-automation-hub"
+            target="_blank"
+            rel="noreferrer"
+          >
+            github.com/Anurag/ai-power-workflow-automation-hub
+          </a>
+        </p>
+      </section>
+    </div>
+  )
+}
+
+export default Developer

--- a/frontend/src/pages/landing/Features.jsx
+++ b/frontend/src/pages/landing/Features.jsx
@@ -1,0 +1,35 @@
+import Navbar from '@/components/landing/Navbar'
+import StarPattern from '@/components/common/StarPattern'
+import './LandingInfo.css'
+
+const Features = () => {
+  return (
+    <div className="info-page">
+      <StarPattern />
+      <div className="stars1"></div>
+      <div className="stars2"></div>
+      <div className="stars3"></div>
+      <Navbar />
+
+      <section className="info-content">
+        <h1 className="info-title">Project Features</h1>
+        <p className="info-subtitle">
+          FlowAI is focused on creating smart workflow automation with AI-assisted actions and trigger-based execution.
+        </p>
+
+        <ul className="info-list">
+          <li>Visual workflow builder to create automation flows quickly.</li>
+          <li>AI node support with Gemini, OpenAI, and Perplexity integrations.</li>
+          <li>Trigger and action-based automation for tools like Gmail and Google Drive.</li>
+          <li>Manual and webhook execution support for custom workflow runs.</li>
+          <li>Real-time workflow execution tracking and status visibility.</li>
+          <li>Workflow management with create, update, and execute capabilities.</li>
+          <li>GitHub integration is currently under development.</li>
+          <li>Jira integration is planned and currently pending.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}
+
+export default Features

--- a/frontend/src/pages/landing/Integrations.jsx
+++ b/frontend/src/pages/landing/Integrations.jsx
@@ -1,0 +1,41 @@
+import Navbar from '@/components/landing/Navbar'
+import StarPattern from '@/components/common/StarPattern'
+import './LandingInfo.css'
+
+const Integrations = () => {
+  return (
+    <div className="info-page">
+      <StarPattern />
+      <div className="stars1"></div>
+      <div className="stars2"></div>
+      <div className="stars3"></div>
+      <Navbar />
+
+      <section className="info-content">
+        <h1 className="info-title">Integrations</h1>
+        <p className="info-subtitle">
+          These integrations are currently available and planned in the FlowAI automation ecosystem.
+        </p>
+
+        <h2 className="info-title">Available Now</h2>
+        <ul className="info-list">
+          <li>Gemini</li>
+          <li>OpenAI</li>
+          <li>Perplexity</li>
+          <li>Gmail</li>
+          <li>Slack</li>
+          <li>Google Drive</li>
+          <li>Google Forms</li>
+        </ul>
+
+        <h2 className="info-title" style={{ marginTop: '24px' }}>Future Integrations</h2>
+        <ul className="info-list">
+          <li>GitHub (under development)</li>
+          <li>Jira (pending)</li>
+        </ul>
+      </section>
+    </div>
+  )
+}
+
+export default Integrations

--- a/frontend/src/pages/landing/LandingInfo.css
+++ b/frontend/src/pages/landing/LandingInfo.css
@@ -1,0 +1,46 @@
+.info-page {
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  color: #ffffff;
+}
+
+.info-content {
+  position: relative;
+  z-index: 2;
+  max-width: 960px;
+  margin: 40px auto 0;
+  padding: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  background: rgba(11, 11, 25, 0.72);
+  backdrop-filter: blur(8px);
+}
+
+.info-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  margin-bottom: 20px;
+}
+
+.info-subtitle {
+  color: #cdd0ff;
+  margin-bottom: 24px;
+  line-height: 1.6;
+}
+
+.info-list {
+  display: grid;
+  gap: 14px;
+  padding-left: 20px;
+  line-height: 1.6;
+}
+
+.info-list li {
+  color: #f0f2ff;
+}
+
+.info-link {
+  color: #88b6ff;
+  text-decoration: underline;
+}


### PR DESCRIPTION
### Motivation
- Wire the landing navbar to actual frontend routes so each item navigates to its own static page instead of using no-op links. 
- Provide static, frontend-only pages to describe Features, Integrations, Developer, and About information for visitors. 
- Keep the onboarding flow link-based and consistent with the landing UI while ensuring no backend dependency for these pages. 

### Description
- Updated the landing navbar to use real `react-router` links and preserved the `Get Started` button linking to ` /auth/login ` by changing `frontend/src/components/landing/Navbar.jsx`. 
- Added public routes for `/features`, `/integrations`, `/developer`, and `/about` in `frontend/src/App.jsx`. 
- Implemented new static pages `frontend/src/pages/landing/Features.jsx`, `frontend/src/pages/landing/Integrations.jsx`, `frontend/src/pages/landing/Developer.jsx`, and `frontend/src/pages/landing/About.jsx`, plus shared styles in `frontend/src/pages/landing/LandingInfo.css`. 
- Adjusted the hero CTA markup in `frontend/src/components/landing/HeroSection.jsx` to use a link wrapper for cleaner navigation behavior. 

### Testing
- Ran `cd frontend && npm run build` and the build completed successfully (Vite produced warnings about chunk sizes but the production build finished). 
- No additional automated unit or integration tests were present or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4e247a348327ac16556c90c3dda5)